### PR TITLE
Fix Food/Door issues and add recipes/loot tables

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 0.0.31-1.16.5:
 update;
+added netherite armor textures;
+improved nest item consumption logic;
+added nest background transparency based on energy;
+dragons can't ride striders;
+updated recipes to use tags;
 fixed crash with 'trap' skeleton horses;
+added additional recipe options for charred meat;
 
 0.0.30:
 disabled NPE spam;

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@ dragons can't ride striders;
 updated recipes to use tags;
 fixed crash with 'trap' skeleton horses;
 added additional recipe options for charred meat;
+fixed issues with dragon doors;
+added reverse recipes for elder dragon bone and heart element;
 
 0.0.30:
 disabled NPE spam;

--- a/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
@@ -29,10 +29,8 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
-
 import javax.annotation.Nullable;
 
-import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
 
 public class DragonDoor extends Block {
     enum Part implements IStringSerializable {
@@ -135,7 +133,7 @@ public class DragonDoor extends Block {
     }
 
     private DoorHingeSide getHinge(BlockItemUseContext blockItemUseContext) {
-        //TODO
+        //TODO Logic handling aligning doors
         IBlockReader iblockreader = blockItemUseContext.getLevel();
         BlockPos blockpos = blockItemUseContext.getClickedPos();
         Direction direction = blockItemUseContext.getHorizontalDirection();
@@ -151,8 +149,8 @@ public class DragonDoor extends Block {
         BlockPos blockpos5 = blockpos1.relative(direction2);
         BlockState blockstate3 = iblockreader.getBlockState(blockpos5);
         int i = (blockstate.isCollisionShapeFullBlock(iblockreader, blockpos2) ? -1 : 0) + (blockstate1.isCollisionShapeFullBlock(iblockreader, blockpos3) ? -1 : 0) + (blockstate2.isCollisionShapeFullBlock(iblockreader, blockpos4) ? 1 : 0) + (blockstate3.isCollisionShapeFullBlock(iblockreader, blockpos5) ? 1 : 0);
-        boolean flag = blockstate.getBlock() == this && blockstate.getValue(PART) == Part.BOTTOM;
-        boolean flag1 = blockstate2.getBlock() == this && blockstate2.getValue(PART) == Part.BOTTOM;
+        boolean flag = blockstate.is(this) && blockstate.getValue(PART) == Part.BOTTOM;
+        boolean flag1 = blockstate2.is(this) && blockstate2.getValue(PART) == Part.BOTTOM;
         if ((!flag || flag1) && i <= 0) {
             if ((!flag1 || flag) && i >= 0) {
                 int j = direction.getStepX();
@@ -160,7 +158,7 @@ public class DragonDoor extends Block {
                 Vector3d vec3d = blockItemUseContext.getClickLocation();
                 double d0 = vec3d.x - (double) blockpos.getX();
                 double d1 = vec3d.z - (double) blockpos.getZ();
-                return (j >= 0 || !(d1 < 0.5D)) && (j <= 0 || !(d1 > 0.5D)) && (k >= 0 || !(d0 > 0.5D)) && (k <= 0 || !(d0 < 0.5D)) ? DoorHingeSide.LEFT : DoorHingeSide.RIGHT;
+                return (j >= 0 || !(d1 < 0.5D)) && (j <= 0 || !(d1 > 0.5D)) && (k >= 0 || !(d0 > 0.5D)) && (k <= 0 || !(d0 < 0.5D)) ? DoorHingeSide.LEFT : DoorHingeSide.RIGHT; 
             } else {
                 return DoorHingeSide.LEFT;
             }

--- a/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
@@ -1,16 +1,12 @@
 package by.jackraidenph.dragonsurvival.blocks;
 
-import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
-import by.jackraidenph.dragonsurvival.handlers.BlockInit;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.DoublePlantBlock;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.PushReaction;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.monster.piglin.PiglinTasks;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
@@ -21,8 +17,6 @@ import net.minecraft.state.EnumProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.state.properties.DoorHingeSide;
-import net.minecraft.state.properties.DoubleBlockHalf;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
@@ -37,6 +31,8 @@ import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
+
+import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
 
 public class DragonDoor extends Block {
     enum Part implements IStringSerializable {
@@ -86,10 +82,11 @@ public class DragonDoor extends Block {
     public BlockState updateShape(BlockState stateIn, Direction facing, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
         Part part = stateIn.getValue(PART);
         //TODO
-        if (facing.getAxis() == Direction.Axis.Y && part == Part.BOTTOM == (facing == Direction.UP)) {
-            return facingState.getBlock() == this && facingState.getValue(PART) != part ? stateIn.setValue(FACING, facingState.getValue(FACING)).setValue(OPEN, facingState.getValue(OPEN)).setValue(HINGE, facingState.getValue(HINGE)).setValue(POWERED, facingState.getValue(POWERED)) : Blocks.AIR.defaultBlockState();
+        if (facing.getAxis() == Direction.Axis.Y && (part == Part.BOTTOM == (facing == Direction.UP) || part == Part.MIDDLE == (facing == Direction.UP))) {
+        	return facingState.getBlock() == this && facingState.getValue(PART) != part ? stateIn.setValue(FACING, facingState.getValue(FACING)).setValue(OPEN, facingState.getValue(OPEN)).setValue(HINGE, facingState.getValue(HINGE)).setValue(POWERED, facingState.getValue(POWERED)) : 
+        		Blocks.AIR.defaultBlockState();
         } else {
-            return part == Part.BOTTOM && facing == Direction.DOWN && !stateIn.canSurvive(worldIn, currentPos) ? Blocks.AIR.defaultBlockState() : super.updateShape(stateIn, facing, facingState, worldIn, currentPos, facingPos);
+        	return part == Part.BOTTOM && facing == Direction.DOWN && !stateIn.canSurvive(worldIn, currentPos) ? Blocks.AIR.defaultBlockState() : super.updateShape(stateIn, facing, facingState, worldIn, currentPos, facingPos);
         }
     }
 
@@ -237,7 +234,7 @@ public class DragonDoor extends Block {
     }
 
     public void neighborChanged(BlockState state, World worldIn, BlockPos pos, Block blockIn, BlockPos fromPos, boolean isMoving) {
-        boolean flag = worldIn.hasNeighborSignal(pos) || worldIn.hasNeighborSignal(pos.relative(state.getValue(PART) == Part.BOTTOM ? Direction.UP : Direction.DOWN));
+    	boolean flag = worldIn.hasNeighborSignal(pos) || worldIn.hasNeighborSignal(pos.relative(state.getValue(PART) == Part.BOTTOM ? Direction.UP : Direction.DOWN));
         if (blockIn != this && flag != state.getValue(POWERED)) {
             if (flag != state.getValue(OPEN)) {
                 this.playSound(worldIn, pos, flag);

--- a/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
@@ -240,10 +240,6 @@ public class DragonDoor extends Block {
 
             worldIn.setBlock(pos, state.setValue(POWERED, flag).setValue(OPEN, flag), 2);
         }
-        BlockState blockStateDown = worldIn.getBlockState(pos.below());
-        if (state.getValue(PART) == Part.TOP && blockStateDown.getBlock() == this) {
-            worldIn.setBlock(pos.below(), blockStateDown.setValue(OPEN, flag), 2);
-        }
     }
 
     public boolean canSurvive(BlockState state, IWorldReader worldIn, BlockPos pos) {

--- a/src/main/java/by/jackraidenph/dragonsurvival/handlers/EventHandler.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/handlers/EventHandler.java
@@ -278,10 +278,10 @@ public class EventHandler {
                 if (dragonStateHandler.getType() == DragonType.CAVE) {
                     if (item == Items.COAL) {
                         itemStack.shrink(1);
-                        playerEntity.getFoodData().eat(1, 1);
+                        playerEntity.getFoodData().eat(1, 0.5F);
                     } else if (item == Items.CHARCOAL) {
                         itemStack.shrink(1);
-                        playerEntity.getFoodData().eat(1, 2);
+                        playerEntity.getFoodData().eat(1, 1.0F);
                     }
                 }
             }

--- a/src/main/java/by/jackraidenph/dragonsurvival/handlers/ItemsInit.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/handlers/ItemsInit.java
@@ -100,7 +100,7 @@ public class ItemsInit {
         elderDragonDust = new Item(new Item.Properties().tab(items)).setRegistryName(DragonSurvivalMod.MODID, "elder_dragon_dust");
         elderDragonBone = new Item(new Item.Properties().tab(items)).setRegistryName(DragonSurvivalMod.MODID, "elder_dragon_bone");
 
-        chargedCoal = new Item(new Item.Properties().tab(items).food(new Food.Builder().nutrition(5).saturationMod(0.8F).build())) {
+        chargedCoal = new Item(new Item.Properties().tab(items).food(new Food.Builder().nutrition(5).saturationMod(0.7F).build())) {
             @Override
             public ActionResult<ItemStack> use(World worldIn, PlayerEntity playerIn, Hand handIn) {
                 DragonStateHandler dragonStateProvider = playerIn.getCapability(DragonStateProvider.DRAGON_CAPABILITY).orElse(null);
@@ -109,7 +109,7 @@ public class ItemsInit {
                 return ActionResult.pass(playerIn.getItemInHand(handIn));
             }
         }.setRegistryName(DragonSurvivalMod.MODID, "charged_coal");
-        charredMeat = new Item(new Item.Properties().tab(items).food(new Food.Builder().nutrition(10).saturationMod(0.6F).meat().build())) {
+        charredMeat = new Item(new Item.Properties().tab(items).food(new Food.Builder().nutrition(10).saturationMod(0.65F).meat().build())) {
             @Override
             public ActionResult<ItemStack> use(World worldIn, PlayerEntity playerIn, Hand handIn) {
                 DragonStateHandler dragonStateProvider = playerIn.getCapability(DragonStateProvider.DRAGON_CAPABILITY).orElse(null);

--- a/src/main/java/by/jackraidenph/dragonsurvival/util/ConfigurationHandler.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/util/ConfigurationHandler.java
@@ -17,6 +17,12 @@ public class ConfigurationHandler {
     public static ForgeConfigSpec.DoubleValue predatorDamageFactor;
     public static ForgeConfigSpec.DoubleValue predatorHealthFactor;
     //public static ForgeConfigSpec.BooleanValue disableClientHandlerSpam;
+    public static ForgeConfigSpec.DoubleValue humanOreDustChance;
+    public static ForgeConfigSpec.DoubleValue dragonOreDustChance;
+    public static ForgeConfigSpec.DoubleValue humanOreBoneChance;
+    public static ForgeConfigSpec.DoubleValue dragonOreBoneChance;
+    //public static ForgeConfigSpec.DoubleValue predatorDustChance;
+    //public static ForgeConfigSpec.DoubleValue predatorBoneChance;
 
     public static class General {
 
@@ -26,6 +32,12 @@ public class ConfigurationHandler {
             predatorDamageFactor = builder.defineInRange("Predator damage factor", 1, 0.5, 10);
             predatorHealthFactor = builder.defineInRange("Predator health factor", 1, 0.2, 5);
             //disableClientHandlerSpam = builder.define("Disable \"Unknown custom packet identifier: dragonsurvival:main\" spam", true);
+            humanOreDustChance = builder.defineInRange("Ore dust chance for human", 0.0033, 0.0, 1.0);
+            dragonOreDustChance = builder.defineInRange("Ore dust chance for dragon", 0.4, 0.0, 1.0);
+            humanOreDustChance = builder.defineInRange("Ore bone chance for human", 0.0, 0.0, 1.0);
+            dragonOreBoneChance = builder.defineInRange("Ore bone chance for dragon", 0.01, 0.0, 1.0);
+            //predatorDustChance = builder.defineInRange("Predator dust chance", 0.3, 0.0, 1.0);
+            //predatorBoneChance = builder.defineInRange("Predator bone chance", 0.0, 0.0, 1.0);
             builder.pop();
 
         }

--- a/src/main/java/by/jackraidenph/dragonsurvival/util/ConfigurationHandler.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/util/ConfigurationHandler.java
@@ -34,7 +34,7 @@ public class ConfigurationHandler {
             //disableClientHandlerSpam = builder.define("Disable \"Unknown custom packet identifier: dragonsurvival:main\" spam", true);
             humanOreDustChance = builder.defineInRange("Ore dust chance for human", 0.0033, 0.0, 1.0);
             dragonOreDustChance = builder.defineInRange("Ore dust chance for dragon", 0.4, 0.0, 1.0);
-            humanOreDustChance = builder.defineInRange("Ore bone chance for human", 0.0, 0.0, 1.0);
+            humanOreBoneChance = builder.defineInRange("Ore bone chance for human", 0.0, 0.0, 1.0);
             dragonOreBoneChance = builder.defineInRange("Ore bone chance for dragon", 0.01, 0.0, 1.0);
             //predatorDustChance = builder.defineInRange("Predator dust chance", 0.3, 0.0, 1.0);
             //predatorBoneChance = builder.defineInRange("Predator bone chance", 0.0, 0.0, 1.0);

--- a/src/main/resources/data/dragonsurvival/loot_tables/entities/magical_predator_entity.json
+++ b/src/main/resources/data/dragonsurvival/loot_tables/entities/magical_predator_entity.json
@@ -1,0 +1,24 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dragonsurvival:elder_dragon_dust"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:random_chance_with_looting",
+          "chance": 0.30,
+          "looting_multiplier": 0.10
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/dragonsurvival/recipes/elder_dragon_bone_from_heart_element.json
+++ b/src/main/resources/data/dragonsurvival/recipes/elder_dragon_bone_from_heart_element.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "dragonsurvival:heart_element"
+    }
+  ],
+  "result": {
+    "item": "dragonsurvival:elder_dragon_bone",
+    "count": 9
+  }
+}

--- a/src/main/resources/data/dragonsurvival/recipes/elder_dragon_dust.json
+++ b/src/main/resources/data/dragonsurvival/recipes/elder_dragon_dust.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "dragonsurvival:elder_dragon_bone"
+    }
+  ],
+  "result": {
+    "item": "dragonsurvival:elder_dragon_dust",
+    "count": 9
+  }
+}

--- a/src/main/resources/data/dragonsurvival/recipes/smelting/charred_meat_from_campfire_cooking.json
+++ b/src/main/resources/data/dragonsurvival/recipes/smelting/charred_meat_from_campfire_cooking.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:campfire_cooking",
+  "ingredient": {
+    "tag": "dragonsurvival:cooked_meats"
+  },
+  "result": "dragonsurvival:charred_meat",
+  "cookingtime": 600
+}

--- a/src/main/resources/data/dragonsurvival/recipes/smelting/charred_meat_from_smoking.json
+++ b/src/main/resources/data/dragonsurvival/recipes/smelting/charred_meat_from_smoking.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:smoking",
+  "ingredient": {
+    "tag": "dragonsurvival:cooked_meats"
+  },
+  "result": "dragonsurvival:charred_meat",
+  "cookingtime": 100
+}

--- a/src/main/resources/data/dragonsurvival/tags/items/cooked_meats.json
+++ b/src/main/resources/data/dragonsurvival/tags/items/cooked_meats.json
@@ -5,6 +5,8 @@
     "minecraft:cooked_chicken",
     "minecraft:cooked_mutton",
     "minecraft:cooked_porkchop",
-    "minecraft:cooked_rabbit"
+    "minecraft:cooked_rabbit",
+    "minecraft:cooked_cod",
+    "minecraft:cooked_salmon"
   ]
 }


### PR DESCRIPTION
Fixed a few incorrect food saturation values and improved their recipes.
Patched issues with doors dropping items in creative, duplicating drops in survival, only the top part being removed from pistons, closing due to neighbor block updates, and not properly aligning with other dragon doors when placed.
Added a loot table for the magical predator.

Threw in some (temporary?) config options for ore drops.
Ore drops should be done via global loot modifiers, not through the block break event.