### PR TITLE
Fix crashing bug with dragon riding and various bug fixes

### DIFF
--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
@@ -3,6 +3,7 @@ package by.jackraidenph.dragonsurvival.mixins;
 import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
 import by.jackraidenph.dragonsurvival.config.ConfigHandler;
 import by.jackraidenph.dragonsurvival.handlers.DragonSizeHandler;
+import by.jackraidenph.dragonsurvival.util.DragonType;
 import com.mojang.realmsclient.gui.ListButton;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntitySize;
@@ -23,6 +24,14 @@ public abstract class MixinEntity extends net.minecraftforge.common.capabilities
 
     protected MixinEntity(Class<Entity> baseClass) {
         super(baseClass);
+    }
+
+    @Inject(at = @At(value = "HEAD"), method = "Lnet/minecraft/entity/Entity;displayFireAnimation()Z", cancellable = true)
+    private void hideCaveDragonFireAnimation(CallbackInfoReturnable<Boolean> ci){
+        DragonStateProvider.getCap((Entity)(Object)this).ifPresent(dragonStateHandler -> {
+            if (dragonStateHandler.getType() == DragonType.CAVE)
+                ci.setReturnValue(false);
+        });
     }
 
     @Inject(at = @At(value = "HEAD"), method = "Lnet/minecraft/entity/Entity;getPassengersRidingOffset()D", cancellable = true)

--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinInventoryScreen.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinInventoryScreen.java
@@ -1,0 +1,58 @@
+package by.jackraidenph.dragonsurvival.mixins;
+
+import by.jackraidenph.dragonsurvival.capability.DragonStateHandler;
+import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.gui.DisplayEffectsScreen;
+import net.minecraft.client.gui.recipebook.IRecipeShownListener;
+import net.minecraft.client.gui.screen.inventory.InventoryScreen;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.entity.EntityRendererManager;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.container.PlayerContainer;
+import net.minecraft.util.text.ITextComponent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(InventoryScreen.class)
+public abstract class MixinInventoryScreen extends DisplayEffectsScreen<PlayerContainer> implements IRecipeShownListener {
+    public MixinInventoryScreen(PlayerContainer p_i51091_1_, PlayerInventory p_i51091_2_, ITextComponent p_i51091_3_) {
+        super(p_i51091_1_, p_i51091_2_, p_i51091_3_);
+    }
+
+    @Redirect(method = "Lnet/minecraft/client/gui/screen/inventory/InventoryScreen;renderEntityInInventory(IIIFFLnet/minecraft/entity/LivingEntity;)V", at = @At(value="INVOKE",
+            target="Lcom/mojang/blaze3d/systems/RenderSystem;runAsFancy(Ljava/lang/Runnable;)V"
+    ))
+    private static void dragonScreenEntityRender(Runnable p_runAsFancy_0_){
+        ClientPlayerEntity player = Minecraft.getInstance().player;
+        if (DragonStateProvider.getCap(player).isPresent() && DragonStateProvider.getCap(player).orElseGet(null).isDragon())
+            DragonStateProvider.getCap(player).ifPresent(dragonStateHandler -> {
+                double bodyYaw = dragonStateHandler.getMovementData().bodyYaw;
+                double headYaw = dragonStateHandler.getMovementData().headYaw;
+                double headPitch = dragonStateHandler.getMovementData().headPitch;
+                dragonStateHandler.getMovementData().bodyYaw = player.yBodyRot; // ?
+                dragonStateHandler.getMovementData().headYaw = player.yHeadRot;
+                dragonStateHandler.getMovementData().headPitch = player.xRot;
+                RenderSystem.runAsFancy(p_runAsFancy_0_);
+                dragonStateHandler.getMovementData().bodyYaw = bodyYaw;
+                dragonStateHandler.getMovementData().headYaw = headYaw;
+                dragonStateHandler.getMovementData().headPitch = headPitch;
+            });
+        else
+            RenderSystem.runAsFancy(p_runAsFancy_0_);
+    }
+
+    @Redirect(method = "Lnet/minecraft/client/gui/screen/inventory/InventoryScreen;renderEntityInInventory(IIIFFLnet/minecraft/entity/LivingEntity;)V", at = @At(value="INVOKE",
+            target="Ljava/lang/Math;atan(D)D"
+    ), require = 2)
+    private static double dragonScreenEntityRenderAtan(double a) {
+        if (DragonStateProvider.isDragon(Minecraft.getInstance().player))
+            return Math.atan(a / 40.0);
+        return Math.atan(a);
+    }
+}

--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinProjectileHelper.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinProjectileHelper.java
@@ -1,5 +1,6 @@
 package by.jackraidenph.dragonsurvival.mixins;
 
+import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
 import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
 import net.minecraft.client.entity.player.RemoteClientPlayerEntity;
 import net.minecraft.entity.Entity;
@@ -24,23 +25,18 @@ public abstract class MixinProjectileHelper {
     at = @At(value = "HEAD"), cancellable = true)
     private static void getEntityHitResultDragonIgnorePassenger(Entity p_221273_0_, Vector3d p_221273_1_, Vector3d p_221273_2_, AxisAlignedBB p_221273_3_, Predicate<Entity> p_221273_4_, double p_221273_5_, CallbackInfoReturnable<EntityRayTraceResult> ci){
         DragonStateProvider.getCap(p_221273_0_).ifPresent(dragonStateHandler -> {
-            if (dragonStateHandler.isDragon()){
+            if (dragonStateHandler.isDragon()) {
                 World world = p_221273_0_.level;
                 double d0 = p_221273_5_;
                 Entity entity = null;
                 Vector3d vector3d = null;
 
-                for (Entity entity1 : world.getEntities(p_221273_0_, p_221273_3_, p_221273_4_)) {
-                    AxisAlignedBB axisalignedbb = entity1.getBoundingBox().inflate((double) entity1.getPickRadius());
+                for(Entity entity1 : world.getEntities(p_221273_0_, p_221273_3_, p_221273_4_)) {
+                    AxisAlignedBB axisalignedbb = entity1.getBoundingBox().inflate((double)entity1.getPickRadius());
                     Optional<Vector3d> optional = axisalignedbb.clip(p_221273_1_, p_221273_2_);
                     if (axisalignedbb.contains(p_221273_1_)) {
-                        if ((entity1.getRootVehicle() == p_221273_0_.getRootVehicle() && !entity1.canRiderInteract())
-                                || (entity1.getId() == dragonStateHandler.getPassengerId() && entity1 instanceof PlayerEntity)){
-                            if (d0 == 0.0D) {
-                                entity = entity1;
-                                vector3d = optional.orElse(p_221273_1_);
-                            }
-                        } else if (d0 >= 0.0D) {
+                        if (d0 >= 0.0D && (!((entity1.getRootVehicle() == p_221273_0_.getRootVehicle() && !entity1.canRiderInteract())
+                                || (entity1.getId() == dragonStateHandler.getPassengerId() && entity1 instanceof PlayerEntity)))) {
                             entity = entity1;
                             vector3d = optional.orElse(p_221273_1_);
                             d0 = 0.0D;
@@ -50,7 +46,7 @@ public abstract class MixinProjectileHelper {
                         double d1 = p_221273_1_.distanceToSqr(vector3d1);
                         if (d1 < d0 || d0 == 0.0D) {
                             if ((entity1.getRootVehicle() == p_221273_0_.getRootVehicle() && !entity1.canRiderInteract())
-                                || (entity1.getId() == dragonStateHandler.getPassengerId() && entity1 instanceof PlayerEntity)){
+                                    || (entity1.getId() == dragonStateHandler.getPassengerId() && entity1 instanceof PlayerEntity)){
                                 if (d0 == 0.0D) {
                                     entity = entity1;
                                     vector3d = vector3d1;

--- a/src/main/resources/dragonsurvival.mixins.json
+++ b/src/main/resources/dragonsurvival.mixins.json
@@ -12,7 +12,8 @@
 	"client": [
 		"AccessorEntityRenderer",
 		"MixinProjectileHelper",
-		"MixinFirstPersonRenderer"
+		"MixinFirstPersonRenderer",
+		"MixinInventoryScreen"
 	],
 	"minVersion": "0.8"
 }


### PR DESCRIPTION
Fix three crashing bugs with dragon riding raytracing. Could use more testing to verify these are 100% gone.
Removed the fire effects from burning cave dragons. (the 3rd person render ones)
Locked the dragon direction in inventory to face forwards.