### PR TITLE
Fix for doors crashing some users due to PC localization.

### DIFF
--- a/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/blocks/DragonDoor.java
@@ -1,5 +1,7 @@
 package by.jackraidenph.dragonsurvival.blocks;
 
+import java.util.Locale;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -47,7 +49,7 @@ public class DragonDoor extends Block {
     	
         @Override
         public String getSerializedName() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ENGLISH);
         }
     }
 
@@ -61,7 +63,7 @@ public class DragonDoor extends Block {
     	
     	@Override
         public String getSerializedName() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ENGLISH);
         }
 	}
 	


### PR DESCRIPTION
Temp fix of locale issues with doors due to literal use of enum names instead of defined strings.
This fixes #49 though there might be other instances within the mod that could crash yet.
All of this should go away with the pending rewrite.