### PR TITLE
QoL config tweaks

### DIFF
--- a/src/main/java/by/jackraidenph/dragonsurvival/config/ConfigUtils.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/config/ConfigUtils.java
@@ -1,0 +1,31 @@
+package by.jackraidenph.dragonsurvival.config;
+
+import net.minecraft.item.Item;
+import net.minecraft.tags.ITag;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConfigUtils {
+    public static List<Item> parseConfigItemList(List<? extends String> values) {
+        List<Item> result = new ArrayList<>();
+
+        for (String entry : values.toArray(new String[0])) {
+            final String[] sEntry = entry.split(":");
+            final ResourceLocation rlEntry = new ResourceLocation(sEntry[0], sEntry[1]);
+
+            if (sEntry[0].equalsIgnoreCase("tag")) {
+                final ITag<Item> tag = ItemTags.getAllTags().getTag(rlEntry);
+
+                if (tag != null)
+                    result.addAll(tag.getValues());
+            } else
+                result.add(ForgeRegistries.ITEMS.getValue(rlEntry));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
@@ -26,6 +26,8 @@ public class ServerConfig {
 	public final ForgeConfigSpec.DoubleValue youngJump;
 	public final ForgeConfigSpec.DoubleValue adultJump;
 	public final ForgeConfigSpec.ConfigValue<List<? extends String>> allowedVehicles;
+	public final ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistedItems;
+	public final ForgeConfigSpec.ConfigValue<List<? extends Integer>> blacklistedSlots;
 
 	// Specifics
     public final ForgeConfigSpec.BooleanValue customDragonFoods;
@@ -138,6 +140,16 @@ public class ServerConfig {
 		allowedVehicles = builder
 				.comment("List of rideable entities. Format: modid:id")
 				.defineList("allowedVehicles", Lists.newArrayList(), value -> value instanceof String);
+		blacklistedItems = builder
+				.comment("List of items that disallowed to be used by dragons. Format: item/tag:modid:id")
+				.defineList("blacklistedItems", Arrays.asList(
+						"minecraft:bow"
+				), this::isValidItemConfig);
+		blacklistedSlots = builder
+				.comment("List of slots to handle blacklistedItems option")
+				.defineList("blacklistedSlots", Arrays.asList(
+						0, 1, 2, 3, 4, 5, 6, 7, 8, 45
+				), value -> value instanceof Integer);
 
 		// Specifics
 		builder.pop().push("specifics");

--- a/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
@@ -1,6 +1,7 @@
 package by.jackraidenph.dragonsurvival.config;
 
 import by.jackraidenph.dragonsurvival.util.DragonLevel;
+import com.google.common.collect.Lists;
 import net.minecraftforge.common.ForgeConfigSpec;
 
 import java.util.Arrays;
@@ -24,6 +25,7 @@ public class ServerConfig {
 	public final ForgeConfigSpec.DoubleValue newbornJump;
 	public final ForgeConfigSpec.DoubleValue youngJump;
 	public final ForgeConfigSpec.DoubleValue adultJump;
+	public final ForgeConfigSpec.ConfigValue<List<? extends String>> allowedVehicles;
 
 	// Specifics
     public final ForgeConfigSpec.BooleanValue customDragonFoods;
@@ -133,6 +135,9 @@ public class ServerConfig {
 		creativeFlight = builder
 				.comment("Whether to use flight similar to creative rather then gliding")
 				.define("alternateFlight", false);
+		allowedVehicles = builder
+				.comment("List of rideable entities. Format: modid:id")
+				.defineList("allowedVehicles", Lists.newArrayList(), value -> value instanceof String);
 
 		// Specifics
 		builder.pop().push("specifics");

--- a/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/config/ServerConfig.java
@@ -28,6 +28,9 @@ public class ServerConfig {
 	public final ForgeConfigSpec.ConfigValue<List<? extends String>> allowedVehicles;
 	public final ForgeConfigSpec.ConfigValue<List<? extends String>> blacklistedItems;
 	public final ForgeConfigSpec.ConfigValue<List<? extends Integer>> blacklistedSlots;
+	public final ForgeConfigSpec.BooleanValue alternateGrowing;
+	public final ForgeConfigSpec.IntValue alternateGrowingFrequency;
+	public final ForgeConfigSpec.DoubleValue alternateGrowingStep;
 
 	// Specifics
     public final ForgeConfigSpec.BooleanValue customDragonFoods;
@@ -150,6 +153,15 @@ public class ServerConfig {
 				.defineList("blacklistedSlots", Arrays.asList(
 						0, 1, 2, 3, 4, 5, 6, 7, 8, 45
 				), value -> value instanceof Integer);
+		alternateGrowing = builder
+				.comment("Defines if dragon should grow without requirement of catalyst items")
+				.define("alternateGrowing", false);
+		alternateGrowingFrequency = builder
+				.comment("Speed of alternateGrowing effect in seconds")
+				.defineInRange("alternateGrowingFrequency", 60, 0, Integer.MAX_VALUE);
+		alternateGrowingStep = builder
+				.comment("Amount of additional dragon size per each iteration of alternateGrowingFrequency for alternateGrowing effect")
+				.defineInRange("alternateGrowingStep", 0.1, 0, Double.MAX_VALUE);
 
 		// Specifics
 		builder.pop().push("specifics");

--- a/src/main/java/by/jackraidenph/dragonsurvival/handlers/DragonGrowthHandler.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/handlers/DragonGrowthHandler.java
@@ -3,6 +3,7 @@ package by.jackraidenph.dragonsurvival.handlers;
 import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
 import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
 import by.jackraidenph.dragonsurvival.config.ConfigHandler;
+import by.jackraidenph.dragonsurvival.config.ConfigUtils;
 import by.jackraidenph.dragonsurvival.network.SyncSize;
 import by.jackraidenph.dragonsurvival.network.SynchronizeDragonCap;
 import net.minecraft.entity.player.PlayerEntity;
@@ -10,16 +11,12 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.SSetPassengersPacket;
-import net.minecraft.tags.ITag;
-import net.minecraft.tags.ItemTags;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.network.PacketDistributor;
-import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,9 +43,9 @@ public class DragonGrowthHandler {
 
             boolean canContinue = false;
 
-            List<Item> newbornList = parseConfigList(ConfigHandler.SERVER.growNewborn.get());
-            List<Item> youngList = parseConfigList(ConfigHandler.SERVER.growYoung.get());
-            List<Item> adultList = parseConfigList(ConfigHandler.SERVER.growAdult.get());
+            List<Item> newbornList = ConfigUtils.parseConfigItemList(ConfigHandler.SERVER.growNewborn.get());
+            List<Item> youngList = ConfigUtils.parseConfigItemList(ConfigHandler.SERVER.growYoung.get());
+            List<Item> adultList = ConfigUtils.parseConfigItemList(ConfigHandler.SERVER.growAdult.get());
 
             List<Item> allowedItems = new ArrayList<>();
 
@@ -119,24 +116,5 @@ public class DragonGrowthHandler {
 
             player.refreshDimensions();
         });
-    }
-
-    private static List<Item> parseConfigList(List<? extends String> values) {
-        List<Item> result = new ArrayList<>();
-
-        for (String entry : values.toArray(new String[0])) {
-            final String[] sEntry = entry.split(":");
-            final ResourceLocation rlEntry = new ResourceLocation(sEntry[0], sEntry[1]);
-
-            if (sEntry[0].equalsIgnoreCase("tag")) {
-                final ITag<Item> tag = ItemTags.getAllTags().getTag(rlEntry);
-
-                if (tag != null)
-                    result.addAll(tag.getValues());
-            } else
-                result.add(ForgeRegistries.ITEMS.getValue(rlEntry));
-        }
-
-        return result;
     }
 }

--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
@@ -4,7 +4,6 @@ import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
 import by.jackraidenph.dragonsurvival.config.ConfigHandler;
 import by.jackraidenph.dragonsurvival.handlers.DragonSizeHandler;
 import by.jackraidenph.dragonsurvival.util.DragonType;
-import com.mojang.realmsclient.gui.ListButton;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntitySize;
 import net.minecraft.entity.Pose;
@@ -52,12 +51,16 @@ public abstract class MixinEntity extends net.minecraftforge.common.capabilities
         }
     }
 
-
-
     @Inject(at = @At(value = "HEAD"), method = "Lnet/minecraft/entity/Entity;isVisuallyCrawling()Z", cancellable = true)
     public void isDragonVisuallyCrawling(CallbackInfoReturnable<Boolean> ci){
         if (DragonStateProvider.isDragon((Entity)(Object)this))
             ci.setReturnValue(false);
+    }
+
+    @Inject(at = @At(value = "RETURN"), method = "canRide", cancellable = true)
+    public void canRide(Entity entity, CallbackInfoReturnable<Boolean> ci) {
+        if (ci.getReturnValue() && DragonStateProvider.isDragon((Entity) (Object) this) && !DragonStateProvider.isDragon(entity))
+                ci.setReturnValue(ConfigHandler.SERVER.allowedVehicles.get().contains(entity.getType().getRegistryName().toString()));
     }
 
     @Redirect(method = "canEnterPose(Lnet/minecraft/entity/Pose;)Z", at = @At(value="INVOKE",

--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinItem.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinItem.java
@@ -1,12 +1,10 @@
 package by.jackraidenph.dragonsurvival.mixins;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
+import by.jackraidenph.dragonsurvival.config.ConfigHandler;
+import by.jackraidenph.dragonsurvival.config.ConfigUtils;
 import by.jackraidenph.dragonsurvival.handlers.DragonFoodHandler;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
@@ -14,9 +12,29 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Item.class)
 public class MixinItem {
+	@Inject(at = @At("HEAD"), method = "inventoryTick", cancellable = true)
+	public void onItemUpdate(ItemStack stack, World world, Entity entity, int slot, boolean isSelected, CallbackInfo ci) {
+		if (!(entity instanceof PlayerEntity) || entity.tickCount % 20 != 0)
+			return;
+
+		PlayerEntity player = (PlayerEntity) entity;
+
+		DragonStateProvider.getCap(player).ifPresent(dragonStateHandler -> {
+			if (dragonStateHandler.isDragon() && ConfigHandler.SERVER.blacklistedSlots.get().contains(slot)
+					&& ConfigUtils.parseConfigItemList(ConfigHandler.SERVER.blacklistedItems.get()).contains(stack.getItem())) {
+				player.drop(stack, false, true);
+				stack.shrink(stack.getCount());;
+			}
+		});
+	}
 
 	@Inject(at = @At("HEAD"), method = "use", cancellable = true)
 	public void dragonUse(World level, PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult<ItemStack>> ci) {
@@ -36,7 +54,7 @@ public class MixinItem {
 			}
 		});
 	}
-	
+
 	@Inject(at = @At("HEAD"), method = "finishUsingItem", cancellable = true)
 	public void dragonFinishUsingItem(ItemStack item, World level, LivingEntity player, CallbackInfoReturnable<ItemStack> ci) {
 		DragonStateProvider.getCap(player).ifPresent(dragonStateHandler -> {
@@ -44,5 +62,5 @@ public class MixinItem {
 				ci.setReturnValue(DragonFoodHandler.isDragonEdible((Item)(Object)this, dragonStateHandler.getType()) ? player.eat(level, item) : item);
 		});
 	}
-	
+
 }


### PR DESCRIPTION
This patch contains 3 main changes:
1. Alternate way of dragon growing mechanic. By enabling this feature in the server config, your dragon will grow slowly grow when you're just playing. Without requirement to use heart elements. But note that you can still use heart elements to accelerate your growing.
2. Blacklisted items and slots. With this feature, you can define a list of items that should be instantly dropped from the dragon inventory. It supports configurable list of slots to add compat with other mods in case you need it.
3. Rideable entities blacklist. With this feature, you can define a list of entities, that cannot be ridden by a dragon to add compat with other third-party mods. It should be crash-safe, so you already can define modded entities, which you don't have in modpack.