### PR TITLE
Patch bugs caused by maxGrowthSize config and double casting

### DIFF
--- a/src/main/java/by/jackraidenph/dragonsurvival/handlers/ClientSide/ClientDragonRender.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/handlers/ClientSide/ClientDragonRender.java
@@ -111,7 +111,8 @@ public class ClientDragonRender
 		            matrixStack.translate(-lookVector.x(), lookVector.y(), -lookVector.z());
 					
 		            double size = cap.getSize();
-	                float scale = (float)Math.max(size / 40, DragonLevel.BABY.maxWidth);
+					// This is some arbitrary scaling that was created back when the maximum size was hard capped at 40. Touching it will cause the render to desync from the hitbox.
+	                float scale = (float)Math.max(size / 40.0D, 0.4D);
 	                String playerModelType = player.getModelName();
 	                LivingRenderer playerRenderer = ((AccessorEntityRendererManager) mc.getEntityRenderDispatcher()).getPlayerRenderers().get(playerModelType);
 	                int eventLight = renderPlayerEvent.getLight();

--- a/src/main/java/by/jackraidenph/dragonsurvival/handlers/DragonSizeHandler.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/handlers/DragonSizeHandler.java
@@ -41,53 +41,54 @@ public class DragonSizeHandler {
     		eyeHeight = calculateModifiedEyeHeight(eyeHeight, overridePose);
     		// Apply changes
 			event.setNewEyeHeight((float)eyeHeight);
-    		event.setNewSize(new EntitySize((float)(width), (float)height, false));
+			// Rounding solves floating point issues that caused the dragon to get stuck inside a block at times.
+    		event.setNewSize(new EntitySize((float)(Math.ceil(width * 100.0D) / 100.0D), (float)(Math.ceil(height * 100.0D) / 100.0D), false));
     		}
         });
     }
 	
     
 	public static double calculateDragonHeight(double size, boolean growsPastHuman) {
-		double height = (size + 4.0F) / 20.0F; // 0.9 -> 2.2
+		double height = (size + 4.0D) / 20.0D; // 0.9 -> Config Dragon Max
 		if (!growsPastHuman)
-			height = 9F * (size + 12F) / 260F; // 0.9 -> 1.8
+			height = 0.9D + 0.9D * (size - 14.0D) / (ConfigHandler.SERVER.maxGrowthSize.get() - 14.0D); // 0.9 -> 1.8 (Min to Human Max)
 		return height;
 	}
 
 	public static double calculateDragonWidth(double size, boolean growsPastHuman) {
-		double width = (3.0F * size + 62.0F) / 260.0F; // 0.4 -> 0.7
+		double width = (3.0D * size + 62.0D) / 260.0D; // 0.4 -> Config Dragon Max
 		if (!growsPastHuman)
-			width = (size + 38) / 130F; // 0.4 -> 0.6
+			width = 0.4D + 0.2D * (size - 14.0D) / (ConfigHandler.SERVER.maxGrowthSize.get() - 14.0D); // 0.4 -> 0.6 (Min to Human Max)
 		return width;
 	}
 
 	public static double calculateDragonEyeHeight(double size, boolean growsPastHuman) {
-		double eyeHeight = (11.0F * size + 54.0F) / 260.0F; // 0.8 -> 1.9
+		double eyeHeight = (11.0D * size + 54.0D) / 260.0D; // 0.8 -> Config Dragon Max
 		if (!growsPastHuman)
-			eyeHeight = (41F * size + 466F) / 1300F; // 14, 0.8 -> 40, 1.62
+			eyeHeight = 0.8D + 0.8D * (size - 14.0D) / (ConfigHandler.SERVER.maxGrowthSize.get() - 14.0D); // 0.8 -> 1.6 (Min to Human Max)
 		return eyeHeight;
 	}
 
 	public static double calculateModifiedHeight(double height, Pose pose, boolean sizeChangesHitbox) {
     	if (pose == Pose.CROUCHING) {
     		if (sizeChangesHitbox)
-    			height *= 5.0F / 6.0F;
+    			height *= 5.0D / 6.0D;
     		else
-    			height = 1.5F;
+    			height = 1.5D;
 		} else if (pose == Pose.SWIMMING || pose == Pose.FALL_FLYING || pose == Pose.SPIN_ATTACK) {
 			if (sizeChangesHitbox)
-				height *= 7.0F / 12.0F;
+				height *= 7.0D / 12.0D;
 			else
-				height = 0.6F;
+				height = 0.6D;
 		}
     	return height;
     }
 
 	public static double calculateModifiedEyeHeight(double eyeHeight, Pose pose) {
     	if (pose == Pose.CROUCHING) {
-    		eyeHeight *= 5.0F / 6.0F;
+    		eyeHeight *= 5.0D / 6.0D;
 		} else if (pose == Pose.SWIMMING || pose == Pose.FALL_FLYING || pose == Pose.SPIN_ATTACK) {
-			eyeHeight *= 7.0F / 12.0F;
+			eyeHeight *= 7.0D / 12.0D;
 		}
     	return eyeHeight;
     }

--- a/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/mixins/MixinEntity.java
@@ -1,5 +1,6 @@
 package by.jackraidenph.dragonsurvival.mixins;
 
+import by.jackraidenph.dragonsurvival.DragonSurvivalMod;
 import by.jackraidenph.dragonsurvival.capability.DragonStateProvider;
 import by.jackraidenph.dragonsurvival.config.ConfigHandler;
 import by.jackraidenph.dragonsurvival.handlers.DragonSizeHandler;
@@ -95,9 +96,9 @@ public abstract class MixinEntity extends net.minecraftforge.common.capabilities
         if (DragonStateProvider.isDragon(entity) && ConfigHandler.SERVER.sizeChangesHitbox.get()){
             double size = DragonStateProvider.getCap(entity).orElseGet(null).getSize();
             double height = DragonSizeHandler.calculateModifiedHeight(DragonSizeHandler.calculateDragonHeight(size, ConfigHandler.SERVER.hitboxGrowsPastHuman.get()), pose, ConfigHandler.SERVER.sizeChangesHitbox.get());
-            double width = DragonSizeHandler.calculateDragonWidth(size, ConfigHandler.SERVER.hitboxGrowsPastHuman.get()) / 2.0F;
-            Vector3d vector3d = new Vector3d(getX() - (double)width, getY(), getZ() - (double)width);
-            Vector3d vector3d1 = new Vector3d(getX() + (double)width, getY() + (double)height, getZ() + (double)width);
+            double width = DragonSizeHandler.calculateDragonWidth(size, ConfigHandler.SERVER.hitboxGrowsPastHuman.get()) / 2.0D;
+            Vector3d vector3d = new Vector3d(getX() - width, getY(), getZ() - width);
+            Vector3d vector3d1 = new Vector3d(getX() + width, getY() + height, getZ() + width);
             return new AxisAlignedBB(vector3d, vector3d1);
         } else
             return getBoundingBoxForPose(pose);

--- a/src/main/java/by/jackraidenph/dragonsurvival/util/DragonLevel.java
+++ b/src/main/java/by/jackraidenph/dragonsurvival/util/DragonLevel.java
@@ -3,21 +3,17 @@ package by.jackraidenph.dragonsurvival.util;
 import net.minecraft.client.resources.I18n;
 
 public enum DragonLevel {
-    BABY(14, 1.1f, 0.4f, 0.9f, "newborn"),
-    YOUNG(20, 1.6f, 0.9f, 1.9f, "young"),
-    ADULT(30, 2.1f, 1.4f, 2.3f, "adult");
+    BABY(14, 1.1f, "newborn"),
+    YOUNG(20, 1.6f, "young"),
+    ADULT(30, 2.1f, "adult");
 
     public int size;
     public float jumpHeight;
-    public float maxWidth;
-    public float maxHeight;
     public String name;
 
-    DragonLevel(int size, float jumpHeight, float maxWidth, float maxHeight, String name_) {
+    DragonLevel(int size, float jumpHeight, String name_) {
         this.size = size;
         this.jumpHeight = jumpHeight;
-        this.maxWidth = maxWidth;
-        this.maxHeight = maxHeight;
         this.name = name_;
     }
     


### PR DESCRIPTION
Added rounding to prevent casting issues resulting in dragons getting stuck on blocks.
hitboxGrowsPastHuman config value no longer breaks when maxGrowthSize is not equal to 40.
Removed unused hard-coded values that now scale with maxGrowthSize config option.