### PR TITLE
Suggestions

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/dragon_editor/DragonEditorScreen.java
@@ -801,10 +801,19 @@ public class DragonEditorScreen extends Screen implements TooltipRender{
 
 			if(cap.getType() != type){
 				Minecraft.getInstance().player.sendSystemMessage(Component.translatable("ds." + type.getTypeName().toLowerCase() + "_dragon_choice"));
+
+				if(type == null && cap.getType() != null){
+					DragonCommand.reInsertClawTools(Minecraft.getInstance().player, cap);
+				}
+
 				cap.setType(type);
 
-				if(!ServerConfig.saveGrowthStage || cap.getSize() == 0){
+				double size = cap.getSavedDragonSize(cap.getType().getTypeName());
+
+				if(!ServerConfig.saveGrowthStage || size == 0){
 					cap.setSize(DragonLevel.NEWBORN.size);
+				} else {
+					cap.setSize(size);
 				}
 
 				cap.setHasWings(ServerConfig.saveGrowthStage ? cap.hasWings() || ServerFlightHandler.startWithWings : ServerFlightHandler.startWithWings);
@@ -815,10 +824,6 @@ public class DragonEditorScreen extends Screen implements TooltipRender{
 				NetworkHandler.CHANNEL.sendToServer(new SyncAltarCooldown(Minecraft.getInstance().player.getId(), Functions.secondsToTicks(ServerConfig.altarUsageCooldown)));
 				NetworkHandler.CHANNEL.sendToServer(new SyncSpinStatus(Minecraft.getInstance().player.getId(), cap.getMovementData().spinAttack, cap.getMovementData().spinCooldown, cap.getMovementData().spinLearned));
 				ClientEvents.sendClientData(new RequestClientData(cap.getType(), cap.getLevel()));
-
-				if(type == null && cap.getType() != null){
-					DragonCommand.reInsertClawTools(Minecraft.getInstance().player, cap);
-				}
 			}
 		});
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/AltarTypeButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/AltarTypeButton.java
@@ -99,6 +99,11 @@ public class AltarTypeButton extends Button implements TooltipRender{
 
 			DragonStateProvider.getCap(player).ifPresent(cap -> {
 				player.level.playSound(player, player.blockPosition(), SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, 1, 0.7f);
+
+				if (ServerConfig.saveGrowthStage) {
+					cap.setSavedDragonSize(cap.getType().getTypeName(), cap.getSize());
+				}
+
 				cap.setType(null);
 				cap.setSize(20F);
 				cap.setHasWings(false);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
@@ -114,7 +114,7 @@ public class DragonCommand{
 		NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> player),new SynchronizeDragonCap(player.getId(), cap.isHiding(), cap.getType(), cap.getSize(), cap.hasWings(), 0));
 		NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> player),new SyncSpinStatus(player.getId(), cap.getMovementData().spinAttack, cap.getMovementData().spinCooldown, cap.getMovementData().spinLearned));
 		NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> player), new SyncSize(player.getId(), size));
-		NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> (ServerPlayer)player), new RequestClientData(cap.getType(), cap.getLevel()));
+		NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), new RequestClientData(cap.getType(), cap.getLevel()));
 		player.refreshDimensions();
 		return 1;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
@@ -32,15 +32,18 @@ import net.minecraftforge.network.PacketDistributor;
 public class Capabilities{
 	public static Capability<VillageRelationShips> VILLAGE_RELATIONSHIP = CapabilityManager.get(new CapabilityToken<>(){});
 	public static Capability<DragonStateHandler> GENERIC_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
+	public static Capability<EntityStateHandler> ENTITY_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 	public static Capability<DragonStateHandler> DRAGON_CAPABILITY = CapabilityManager.get(new CapabilityToken<>(){});
 
 	@SubscribeEvent
 	public static void attachCapabilities(AttachCapabilitiesEvent<Entity> event){
-		if(!(event.getObject() instanceof Player player))
+		if (!(event.getObject() instanceof Player player)) {
 			return;
+		}
 
-		if(event.getObject().level.isClientSide && isFakePlayer(player))
+		if (event.getObject().getLevel().isClientSide() && isFakePlayer(player)) {
 			return;
+		}
 
 		DragonStateProvider provider = new DragonStateProvider();
 		event.addCapability(new ResourceLocation("dragonsurvival", "playerstatehandler"), provider);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateProvider.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateProvider.java
@@ -5,6 +5,7 @@ import com.ibm.icu.impl.Pair;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
@@ -41,6 +42,14 @@ public class DragonStateProvider implements ICapabilitySerializable<CompoundTag>
 
 			return entity.getCapability(Capabilities.DRAGON_CAPABILITY);
 		}
+	}
+
+	public static LazyOptional<? extends EntityStateHandler> getEntityCap(Entity entity){
+		if (entity instanceof Player) {
+			return entity.getCapability(Capabilities.DRAGON_CAPABILITY);
+		}
+
+		return entity.getCapability(Capabilities.ENTITY_CAPABILITY);
 	}
 
 	public void invalidate(){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/EntityStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/EntityStateHandler.java
@@ -1,0 +1,14 @@
+package by.dragonsurvivalteam.dragonsurvival.common.capability;
+
+import net.minecraft.world.phys.Vec3;
+
+public class EntityStateHandler {
+    // Last entity this entity recieved a debuff from
+    public int lastAfflicted = -1;
+
+    // Amount of times the last chain attack has chained
+    public int chainCount = 0;
+
+    // TODO : Does not seem to be used yet?
+    public Vec3 lastPos;
+}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/EntityStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/EntityStateHandler.java
@@ -9,6 +9,5 @@ public class EntityStateHandler {
     // Amount of times the last chain attack has chained
     public int chainCount = 0;
 
-    // TODO : Does not seem to be used yet?
     public Vec3 lastPos;
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/provider/DragonStateProvider.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/provider/DragonStateProvider.java
@@ -13,8 +13,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 
+// FIXME :: Why does this still exist as a duplicate
 public class DragonStateProvider implements ICapabilitySerializable<CompoundTag>{
-
 	private final DragonStateHandler handlerObject = new DragonStateHandler();
 	private final LazyOptional<DragonStateHandler> instance = LazyOptional.of(() -> handlerObject);
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/ClawToolHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/ClawToolHandler.java
@@ -67,6 +67,8 @@ public class ClawToolHandler{
 
 	@SubscribeEvent
 	public static void playerDieEvent(LivingDropsEvent event){
+		// FIXME :: Add support for SoulBound etc.
+
 		Entity ent = event.getEntity();
 
 		if(ent instanceof Player player){
@@ -77,7 +79,10 @@ public class ClawToolHandler{
 					ItemStack stack = handler.getClawToolData().getClawsInventory().getItem(i);
 
 					if(!stack.isEmpty()){
-						event.getDrops().add(new ItemEntity(player.level, player.getX(), player.getY(), player.getZ(), stack));
+						if (!EnchantmentHelper.hasVanishingCurse(stack)) {
+							event.getDrops().add(new ItemEntity(player.level, player.getX(), player.getY(), player.getZ(), stack));
+						}
+
 						handler.getClawToolData().getClawsInventory().setItem(i, ItemStack.EMPTY);
 					}
 				}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/growth/StarBoneItem.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/growth/StarBoneItem.java
@@ -41,7 +41,6 @@ public class StarBoneItem extends Item{
 					size = Math.max(size, DragonLevel.NEWBORN.size);
 					dragonStateHandler.setSize(size, playerIn);
 
-
 					if(!playerIn.isCreative()){
 						playerIn.getItemInHand(handIn).shrink(1);
 					}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/CaveDragon/active/NetherBreathAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/CaveDragon/active/NetherBreathAbility.java
@@ -278,19 +278,18 @@ public class NetherBreathAbility extends BreathAbility{
 
 	@Override
 	public void onEntityHit(LivingEntity entityHit){
-		//Short enough fire duration to not cause fire damage but still drop cooked items
 		if(!entityHit.isOnFire()){
+			// Short enough fire duration to not cause fire damage but still drop cooked items
 			entityHit.setRemainingFireTicks(1);
 		}
 
 		super.onEntityHit(entityHit);
 
 		if(!entityHit.level.isClientSide){
-			DragonStateHandler handler = DragonUtils.getHandler(player);
 			BurnAbility burnAbility = DragonAbilities.getSelfAbility(player, BurnAbility.class);
 
 			if(entityHit.getRandom().nextInt(100) < burnAbility.level * 15){
-				DragonUtils.getHandler(entityHit).lastAfflicted = player != null ? player.getId() : -1;
+				DragonUtils.getEntityHandler(entityHit).lastAfflicted = player != null ? player.getId() : -1;
 				entityHit.addEffect(new MobEffectInstance(DragonEffects.BURN, Functions.secondsToTicks(10), 0, false, true));
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/ForestBreathAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/ForestBreathAbility.java
@@ -267,7 +267,7 @@ public class ForestBreathAbility extends BreathAbility{
 
 		if(!entityHit.level.isClientSide){
 			if(entityHit.getRandom().nextInt(100) < 30){
-				DragonUtils.getHandler(entityHit).lastAfflicted = player != null ? player.getId() : -1;
+				DragonUtils.getEntityHandler(entityHit).lastAfflicted = player != null ? player.getId() : -1;
 				entityHit.addEffect(new MobEffectInstance(DragonEffects.DRAIN, Functions.secondsToTicks(10), 0, false, true));
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/SeaDragon/active/StormBreathAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/SeaDragon/active/StormBreathAbility.java
@@ -5,7 +5,7 @@ import by.dragonsurvivalteam.dragonsurvival.client.particles.SeaDragon.LargeLigh
 import by.dragonsurvivalteam.dragonsurvival.client.particles.SeaDragon.SmallLightningParticleData;
 import by.dragonsurvivalteam.dragonsurvival.client.sounds.SoundRegistry;
 import by.dragonsurvivalteam.dragonsurvival.client.sounds.StormBreathSound;
-import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
+import by.dragonsurvivalteam.dragonsurvival.common.capability.EntityStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.AbstractDragonType;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.DragonTypes;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigOption;
@@ -23,7 +23,6 @@ import com.mojang.math.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.client.resources.sounds.SoundInstance;
-import net.minecraft.client.resources.sounds.TickableSoundInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.DustParticleOptions;
@@ -34,6 +33,7 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LightningBolt;
 import net.minecraft.world.entity.LivingEntity;
@@ -233,15 +233,15 @@ public class StormBreathAbility extends BreathAbility{
 
 			if(!chargedSpreadBlacklist.contains(ResourceHelper.getKey(source).toString())){
 				if(target != source){
-					DragonStateHandler capSource = DragonUtils.getHandler(source);
-					DragonStateHandler cap = DragonUtils.getHandler(target);
+					EntityStateHandler capSource = DragonUtils.getEntityHandler(source);
+					EntityStateHandler entityCap = DragonUtils.getEntityHandler(target);
 
-					cap.chainCount = capSource.chainCount + 1;
+					entityCap.chainCount = capSource.chainCount + 1;
 
 					if(!target.level.isClientSide){
 						if(target.getRandom().nextInt(100) < 40){
-							if(cap.chainCount < chargedEffectMaxChain || chargedEffectMaxChain == -1){
-								cap.lastAfflicted = player != null ? player.getId() : -1;
+							if(entityCap.chainCount < chargedEffectMaxChain || chargedEffectMaxChain == -1){
+								entityCap.lastAfflicted = player != null ? player.getId() : -1;
 								target.addEffect(new MobEffectInstance(DragonEffects.CHARGED, Functions.secondsToTicks(10), 0, false, true));
 							}
 						}
@@ -295,7 +295,7 @@ public class StormBreathAbility extends BreathAbility{
 		if(!entity.level.isClientSide){
 			if(!chargedBlacklist.contains(ResourceHelper.getKey(entity).toString())){
 				if(entity.getRandom().nextInt(100) < 40){
-					DragonStateHandler cap = DragonUtils.getHandler(entity);
+					EntityStateHandler cap = DragonUtils.getEntityHandler(entity);
 
 					cap.lastAfflicted = player.getId();
 					cap.chainCount = 1;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonUtils.java
@@ -22,7 +22,7 @@ public class DragonUtils{
 
 	public static EntityStateHandler getEntityHandler(Entity entity){
 		if (entity == null) {
-			return null;
+			return new EntityStateHandler();
 		}
 
 		LazyOptional<EntityStateHandler> cap = (LazyOptional<EntityStateHandler>) DragonStateProvider.getEntityCap(entity);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonUtils.java
@@ -2,17 +2,39 @@ package by.dragonsurvivalteam.dragonsurvival.util;
 
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.common.capability.EntityStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.AbstractDragonType;
 import com.google.common.base.Objects;
 import net.minecraft.world.entity.Entity;
-
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.common.util.LazyOptional;
 
 public class DragonUtils{
 	public static DragonStateHandler getHandler(Entity entity){
-		return entity != null ? DragonStateProvider.getCap(entity).orElse(new DragonStateHandler()) : new DragonStateHandler();
+		if (entity == null) {
+			return new DragonStateHandler();
+		}
+
+		LazyOptional<DragonStateHandler> cap = DragonStateProvider.getCap(entity);
+
+		return cap.orElse(new DragonStateHandler());
 	}
-	
+
+	public static EntityStateHandler getEntityHandler(Entity entity){
+		if (entity == null) {
+			return null;
+		}
+
+		LazyOptional<EntityStateHandler> cap = (LazyOptional<EntityStateHandler>) DragonStateProvider.getEntityCap(entity);
+
+		return cap.orElse(new EntityStateHandler());
+	}
+
 	public static boolean isDragon(Entity entity){
+		if (!(entity instanceof Player)) {
+			return false;
+		}
+
 		return DragonStateProvider.getCap(entity).filter(DragonStateHandler::isDragon).isPresent();
 	}
 
@@ -21,6 +43,10 @@ public class DragonUtils{
 	}
 
 	public static boolean isDragonType(Entity entity, AbstractDragonType dragonType){
+		if (!(entity instanceof Player)) {
+			return false;
+		}
+
 		return isDragonType(getHandler(entity), dragonType);
 	}
 	


### PR DESCRIPTION
* Growth sized is now saved per dragon type
* Entities should use a simpler interface
* Fixed a bug where `reInsertClawTools` would not be reached (DragonEditorScreen.java)
* Added checks if entity is a dragon for dragon-related code (to avoid the creation of unnecessary DragonStateHandlers)

Result of a charged zombie using the simpler interface (player could be found):
![image](https://github.com/DragonSurvivalTeam/DragonSurvival/assets/22003703/0b2ffc33-33ec-4555-a026-92f5544da68d)

There is an issue when you switch that the camera view-point somtimes does not reset (until your size changes due to grow etc. or you press `Shift`)