### PR TITLE
Minor things

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -53,9 +53,13 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 	public boolean clawsMenu = false;
 	private boolean buttonClicked;
 
-	private static final HashMap<String, ResourceLocation> textures;
+	private static HashMap<String, ResourceLocation> textures;
 
 	static {
+		initResources();
+	}
+
+	private static void initResources() {
 		textures = new HashMap<>();
 
 		Set<String> keys = DragonTypes.staticTypes.keySet();
@@ -284,6 +288,10 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 		}
 
 		if(clawsMenu){
+			if (textures == null || textures.isEmpty()) {
+				initResources();
+			}
+
 			double curSize = handler.getSize();
 			float progress = 0;
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -11,6 +11,8 @@ import by.dragonsurvivalteam.dragonsurvival.client.handlers.KeyInputHandler;
 import by.dragonsurvivalteam.dragonsurvival.client.util.RenderingUtils;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.AbstractDragonType;
+import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.DragonTypes;
 import by.dragonsurvivalteam.dragonsurvival.common.handlers.DragonGrowthHandler;
 import by.dragonsurvivalteam.dragonsurvival.config.ConfigHandler;
 import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
@@ -37,10 +39,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
+import java.util.*;
 
 public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer>{
 	public static final ResourceLocation INVENTORY_TOGGLE_BUTTON = new ResourceLocation(DragonSurvivalMod.MODID, "textures/gui/inventory_button.png");
@@ -54,15 +53,45 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 	public boolean clawsMenu = false;
 	private boolean buttonClicked;
 
+	private static final HashMap<String, ResourceLocation> textures;
+
+	static {
+		textures = new HashMap<>();
+
+		Set<String> keys = DragonTypes.staticTypes.keySet();
+
+		for (String key : keys) {
+			AbstractDragonType type = DragonTypes.staticTypes.get(key);
+
+			String start = "textures/gui/growth/";
+			String end = ".png";
+
+			for (int i = 1; i < 4; i++) {
+				String growthResource = getTexture(type, "growth", i);
+				textures.put(growthResource, new ResourceLocation(DragonSurvivalMod.MODID, start + growthResource + end));
+			}
+
+			String circleResource = getTexture(type, "circle", 0);
+			textures.put(circleResource, new ResourceLocation(DragonSurvivalMod.MODID, start + circleResource + end));
+		}
+	}
+
+	private static String getTexture(final AbstractDragonType type, final String textureType, int level) {
+		String texture = textureType + "_" + type.getTypeName().toLowerCase();
+
+		if (textureType.equals("growth")) {
+			texture += "_" + level;
+		}
+
+		return texture;
+	}
 
 	public DragonScreen(DragonContainer screenContainer, Inventory inv, Component titleIn){
 		super(screenContainer, inv, titleIn);
 		passEvents = true;
 		player = inv.player;
 
-		DragonStateProvider.getCap(player).ifPresent(cap -> {
-			clawsMenu = cap.getClawToolData().isClawsMenuOpen();
-		});
+		DragonStateProvider.getCap(player).ifPresent(cap -> clawsMenu = cap.getClawToolData().isClawsMenuOpen());
 
 		imageWidth = 203;
 		imageHeight = 166;
@@ -287,7 +316,7 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			RenderSystem.enableTexture();
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
-			RenderSystem.setShaderTexture(0, new ResourceLocation(DragonSurvivalMod.MODID, "textures/gui/growth/circle_" + handler.getTypeName().toLowerCase() + ".png"));
+			RenderSystem.setShaderTexture(0, textures.get(getTexture(handler.getType(), "circle", 0)));
 			RenderingUtils.drawTexturedCircle(stack, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, sides, progress, -0.5);
 
 			RenderSystem.disableTexture();
@@ -297,7 +326,7 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
-			RenderSystem.setShaderTexture(0, new ResourceLocation(DragonSurvivalMod.MODID, "textures/gui/growth/growth_" + handler.getTypeName().toLowerCase() + "_" + (handler.getLevel().ordinal() + 1) + ".png"));
+			RenderSystem.setShaderTexture(0, textures.get(getTexture(handler.getType(), "growth", handler.getLevel().ordinal() + 1)));
 			blit(stack, circleX + 6, circleY + 6, 0, 0, 20, 20, 20, 20);
 
 			stack.popPose();

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -71,23 +71,17 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			String end = ".png";
 
 			for (int i = 1; i <= DragonLevel.values().length; i++) {
-				String growthResource = getTexture(type, "growth", i);
+				String growthResource = createTextureKey(type, "growth", "_" + i);
 				textures.put(growthResource, new ResourceLocation(DragonSurvivalMod.MODID, start + growthResource + end));
 			}
 
-			String circleResource = getTexture(type, "circle", 0);
+			String circleResource = createTextureKey(type, "circle", "");
 			textures.put(circleResource, new ResourceLocation(DragonSurvivalMod.MODID, start + circleResource + end));
 		}
 	}
 
-	private static String getTexture(final AbstractDragonType type, final String textureType, int level) {
-		String texture = textureType + "_" + type.getTypeName().toLowerCase();
-
-		if (textureType.equals("growth")) {
-			texture += "_" + level;
-		}
-
-		return texture;
+	private static String createTextureKey(final AbstractDragonType type, final String textureType, final String addition) {
+		return textureType + "_" + type.getTypeName().toLowerCase() + addition;
 	}
 
 	public DragonScreen(DragonContainer screenContainer, Inventory inv, Component titleIn){
@@ -324,7 +318,7 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			RenderSystem.enableTexture();
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
-			RenderSystem.setShaderTexture(0, textures.get(getTexture(handler.getType(), "circle", 0)));
+			RenderSystem.setShaderTexture(0, textures.get(createTextureKey(handler.getType(), "circle", "")));
 			RenderingUtils.drawTexturedCircle(stack, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, sides, progress, -0.5);
 
 			RenderSystem.disableTexture();
@@ -338,7 +332,7 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
-			RenderSystem.setShaderTexture(0, textures.get(getTexture(handler.getType(), "growth", handler.getLevel().ordinal() + 1)));
+			RenderSystem.setShaderTexture(0, textures.get(createTextureKey(handler.getType(), "growth", "_" + (handler.getLevel().ordinal() + 1))));
 			blit(stack, circleX + 6, circleY + 6, 0, 0, 20, 20, 20, 20);
 
 			stack.popPose();

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -329,11 +329,11 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			// Don't get overlayed by other rendered elements
 			RenderSystem.enableDepthTest();
 			stack.translate(0, 0, 150);
-
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
 			RenderSystem.setShaderTexture(0, textures.get(createTextureKey(handler.getType(), "growth", "_" + (handler.getLevel().ordinal() + 1))));
 			blit(stack, circleX + 6, circleY + 6, 0, 0, 20, 20, 20, 20);
+			RenderSystem.disableDepthTest();
 
 			stack.popPose();
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -66,7 +66,7 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			String start = "textures/gui/growth/";
 			String end = ".png";
 
-			for (int i = 1; i < 4; i++) {
+			for (int i = 1; i <= DragonLevel.values().length; i++) {
 				String growthResource = getTexture(type, "growth", i);
 				textures.put(growthResource, new ResourceLocation(DragonSurvivalMod.MODID, start + growthResource + end));
 			}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/DragonScreen.java
@@ -324,6 +324,10 @@ public class DragonScreen extends EffectRenderingInventoryScreen<DragonContainer
 			RenderingUtils.drawSmoothCircle(stack, circleX + radius, circleY + radius, radius - thickness, sides, 1, 0);
 			RenderSystem.enableTexture();
 
+			// Don't get overlayed by other rendered elements
+			RenderSystem.enableDepthTest();
+			stack.translate(0, 0, 150);
+
 			RenderSystem.setShader(GameRenderer::getPositionTexShader);
 			RenderSystem.setShaderColor(1F, 1F, 1F, 1.0f);
 			RenderSystem.setShaderTexture(0, textures.get(getTexture(handler.getType(), "growth", handler.getLevel().ordinal() + 1)));

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientGrowthHudHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientGrowthHudHandler.java
@@ -95,6 +95,7 @@ public class ClientGrowthHudHandler{
 					nextProgess = (float)(progress + perSide);
 					num = 2;
 				}
+				// FIXME :: Initialize them once
 
 				RenderSystem.setShaderTexture(0, new ResourceLocation(DragonSurvivalMod.MODID, "textures/gui/growth/circle_" + num + ".png"));
 				RenderingUtils.drawTexturedCircle(mStack, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, 6, nextProgess, -0.5);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/DragonAltarHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/DragonAltarHandler.java
@@ -3,7 +3,6 @@ package by.dragonsurvivalteam.dragonsurvival.client.handlers;
 import by.dragonsurvivalteam.dragonsurvival.client.gui.DragonAltarGUI;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -11,24 +10,21 @@ import net.minecraftforge.fml.common.Mod;
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class DragonAltarHandler {
     public static boolean openingAltar = false;
-    public static void OpenAltar()
-    {
-        if (Minecraft.getInstance().player != null
-                && Minecraft.getInstance().screen == null
-                && !Minecraft.getInstance().player.isDeadOrDying())
+
+    public static void OpenAltar() {
+        if (Minecraft.getInstance().player != null && Minecraft.getInstance().screen == null && !Minecraft.getInstance().player.isDeadOrDying()) {
             Minecraft.getInstance().setScreen(new DragonAltarGUI());
-        else
+        } else {
             openingAltar = true;
+        }
     }
+
     @SubscribeEvent
-    public static void onPlayerTick(TickEvent.PlayerTickEvent tickEvent)
-    {
-        if (openingAltar){
+    public static void onPlayerTick(final TickEvent.PlayerTickEvent tickEvent) {
+        if (openingAltar && tickEvent.side.isClient()) {
             Minecraft minecraft = Minecraft.getInstance();
-            if(
-                    minecraft.screen == null &&
-                    minecraft.player != null && !minecraft.player.isDeadOrDying()
-            ){
+
+            if (minecraft.screen == null && minecraft.player != null && !minecraft.player.isDeadOrDying()) {
                 minecraft.setScreen(new DragonAltarGUI());
                 openingAltar = false;
             }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/magic/ClientMagicHUDHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/magic/ClientMagicHUDHandler.java
@@ -24,7 +24,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.client.ForgeRenderTypes;
 import net.minecraftforge.client.gui.overlay.ForgeGui;
 import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 
@@ -80,40 +79,39 @@ public class ClientMagicHUDHandler{
 
 		DragonStateProvider.getCap(playerEntity).ifPresent(cap -> {
 			ActiveDragonAbility ability = cap.getMagicData().getAbilityFromSlot(cap.getMagicData().getSelectedAbilitySlot());
-			if(ability == null)
+
+			if (ability == null || ability.canConsumeMana(playerEntity)) {
+				gui.renderExperienceBar(mStack, x);
 				return;
+			}
 
-			if (ManaHandler.getCurrentMana(playerEntity) < ability.getManaCost() && ability.canConsumeMana(playerEntity)){
-				Window window = Minecraft.getInstance().getWindow();
+			Window window = Minecraft.getInstance().getWindow();
 
-				int screenWidth = window.getGuiScaledWidth();
-				int screenHeight = window.getGuiScaledHeight();
+			int screenWidth = window.getGuiScaledWidth();
+			int screenHeight = window.getGuiScaledHeight();
 
-				RenderSystem.setShaderTexture(0, widgetTextures);
-				int i = Minecraft.getInstance().player.getXpNeededForNextLevel();
-				if(i > 0){
-					int j = 182;
-					int k = (int)(Minecraft.getInstance().player.experienceProgress * 183.0F);
-					int l = screenHeight - 32 + 3;
-					blit(mStack, x, l, 0, 164, 182, 5);
-					if(k > 0)
-						blit(mStack, x, l, 0, 169, k, 5);
-				}
+			RenderSystem.setShaderTexture(0, widgetTextures);
+			int i = Minecraft.getInstance().player.getXpNeededForNextLevel();
+			if(i > 0){
+				int j = 182;
+				int k = (int)(Minecraft.getInstance().player.experienceProgress * 183.0F);
+				int l = screenHeight - 32 + 3;
+				blit(mStack, x, l, 0, 164, 182, 5);
+				if(k > 0)
+					blit(mStack, x, l, 0, 169, k, 5);
+			}
 
-				if(Minecraft.getInstance().player.experienceLevel > 0){
-					String s = "" + Minecraft.getInstance().player.experienceLevel;
-					int i1 = (screenWidth - Minecraft.getInstance().font.width(s)) / 2;
-					int j1 = screenHeight - 31 - 4;
-					Minecraft.getInstance().font.draw(mStack, s, (float)(i1 + 1), (float)j1, 0);
-					Minecraft.getInstance().font.draw(mStack, s, (float)(i1 - 1), (float)j1, 0);
-					Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)(j1 + 1), 0);
-					Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)(j1 - 1), 0);
-					Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)j1, new Color(243, 48, 59).getRGB());
-				}
+			if(Minecraft.getInstance().player.experienceLevel > 0){
+				String s = "" + Minecraft.getInstance().player.experienceLevel;
+				int i1 = (screenWidth - Minecraft.getInstance().font.width(s)) / 2;
+				int j1 = screenHeight - 31 - 4;
+				Minecraft.getInstance().font.draw(mStack, s, (float)(i1 + 1), (float)j1, 0);
+				Minecraft.getInstance().font.draw(mStack, s, (float)(i1 - 1), (float)j1, 0);
+				Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)(j1 + 1), 0);
+				Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)(j1 - 1), 0);
+				Minecraft.getInstance().font.draw(mStack, s, (float)i1, (float)j1, new Color(243, 48, 59).getRGB());
 			}
 		});
-
-		gui.renderExperienceBar(mStack, x);
 	}
 
 	public static void blit(PoseStack p_238474_1_, int p_238474_2_, int p_238474_3_, int p_238474_4_, int p_238474_5_, int p_238474_6_, int p_238474_7_){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
@@ -294,7 +294,6 @@ public class ClientDragonRender{
 				if(!(throwable instanceof NullPointerException) || ClientConfig.clientDebugMessages){
 					throwable.printStackTrace();
 				}
-				matrixStack.popPose();
 			}finally{
 				matrixStack.popPose();
 			}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
@@ -13,7 +13,6 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
 import software.bernie.geckolib3.core.processor.IBone;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonTypes.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonTypes.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class DragonTypes {
-	private static HashMap<String, Supplier<AbstractDragonType>> classMappings = new HashMap<>();
-	private static HashMap<String, AbstractDragonType> staticTypes = new HashMap<>();
+	private static final HashMap<String, Supplier<AbstractDragonType>> classMappings = new HashMap<>();
+	public static final HashMap<String, AbstractDragonType> staticTypes = new HashMap<>();
 
 	public static CaveDragonType CAVE;
 	public static SeaDragonType SEA;


### PR DESCRIPTION
* Set the depth render level for the growth dragon icon from the dragon claw menu
* Initialize the used resource locations once instead of constantly re-creating them per render tick

This happens when you use https://www.curseforge.com/minecraft/mc-mods/emi e.g. (and the depth change fixes it)

![image](https://github.com/DragonSurvivalTeam/DragonSurvival/assets/22003703/8a02f42b-86e6-42c6-b6bc-898dfd24ba39)

->

![image](https://github.com/DragonSurvivalTeam/DragonSurvival/assets/22003703/35d21bcb-4b97-4a44-80d7-aba79298e495)
