### PR TITLE
Hunter crit damage compatibility and attack range modifiers

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -104,6 +104,9 @@ public class DragonStateHandler extends EntityStateHandler {
 
             AttributeModifier reach = DragonModifiers.buildReachMod(size);
 			DragonModifiers.updateReachModifier(player, reach);
+			
+			AttributeModifier attackRange = DragonModifiers.buildAttackRangeMod(size);
+			DragonModifiers.updateAttackRangeModifier(player, attackRange);
 		} else {
             // Remove the dragon attribute modifiers
 			AttributeModifier oldMod = DragonModifiers.getHealthModifier(player);
@@ -127,6 +130,12 @@ public class DragonStateHandler extends EntityStateHandler {
 			oldMod = DragonModifiers.getReachModifier(player);
 			if (oldMod != null) {
 				AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.REACH_DISTANCE.get()));
+				max.removeModifier(oldMod);
+			}
+			
+			oldMod = DragonModifiers.getAttackRangeModifier(player);
+			if (oldMod != null) {
+				AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get()));
 				max.removeModifier(oldMod);
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
@@ -120,7 +120,7 @@ public class MagicHandler{
 				BlockState bl = player.getFeetBlockState();
 				BlockState below = player.level.getBlockState(player.blockPosition().below());
 
-				if(bl.getMaterial() == Material.PLANT || bl.getMaterial() == Material.REPLACEABLE_PLANT || below.getMaterial() == Material.GRASS || below.getMaterial() == Material.PLANT || below.getMaterial() == Material.REPLACEABLE_PLANT){
+				if(bl.getMaterial() == Material.PLANT || bl.getMaterial() == Material.REPLACEABLE_PLANT || bl.getMaterial() == Material.GRASS || below.getMaterial() == Material.PLANT || below.getMaterial() == Material.REPLACEABLE_PLANT){
 					player.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 10, 0, false, false));
 				}
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
@@ -120,7 +120,7 @@ public class MagicHandler{
 				BlockState bl = player.getFeetBlockState();
 				BlockState below = player.level.getBlockState(player.blockPosition().below());
 
-				if(bl.getMaterial() == Material.PLANT || bl.getMaterial() == Material.REPLACEABLE_PLANT || bl.getMaterial() == Material.GRASS || below.getMaterial() == Material.PLANT || below.getMaterial() == Material.REPLACEABLE_PLANT){
+				if(bl.getMaterial() == Material.PLANT || bl.getMaterial() == Material.REPLACEABLE_PLANT || below.getMaterial() == Material.GRASS || below.getMaterial() == Material.PLANT || below.getMaterial() == Material.REPLACEABLE_PLANT){
 					player.addEffect(new MobEffectInstance(MobEffects.INVISIBILITY, 10, 0, false, false));
 				}
 
@@ -243,7 +243,7 @@ public class MagicHandler{
 			if(player.hasEffect(DragonEffects.HUNTER)){
 				MobEffectInstance hunter = player.getEffect(DragonEffects.HUNTER);
 				player.removeEffect(DragonEffects.HUNTER);
-				event.setDamageModifier((float)((hunter.getAmplifier() + 1) * HunterAbility.hunterDamageBonus));
+				event.setDamageModifier(event.getDamageModifier() + (float)((hunter.getAmplifier() + 1) * HunterAbility.hunterDamageBonus));
 				event.setResult(Result.ALLOW);
 			}
 		});

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
@@ -75,8 +75,12 @@ public class ServerConfig{
 	public static Double maxGrowthSize = 60.0;
 
 	@ConfigRange( min = 0, max = 1000000.0 )
-	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "reachBonus", comment = "The bonus that is given to dragons at ever 60 size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default value. Only applies to block mining." )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "reachBonus", comment = "The bonus that is given to dragons at every 60 size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default value. Only applies to block mining." )
 	public static Double reachBonus = 0.5;
+	
+	@ConfigRange( min = 0, max = 1000000.0 )
+	@ConfigOption ( side = ConfigSide.SERVER, category = "growth", key = "attackRangeBonus", comment = "The bonus that is given to dragons at every 60 size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default value. Only applies to combat." )
+	public static Double attackRangeBonus = 0.5;
 
 	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "saveGrowthStage", comment = "Should the growth stage of a dragon be saved even when you change. Does not affect the saving progress of magic (use saveAllAbilities). The author does not approve of weredragons, but if you insist..." )
 	public static Boolean saveGrowthStage = false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
@@ -42,8 +42,8 @@ public class HunterAbility extends ChargeCastAbility{
 	public static Double hunterCasttime = 3.0;
 
 	@ConfigRange( min = 0.0, max = 100.0 )
-	@ConfigOption( side = ConfigSide.SERVER, category = {"magic", "abilities", "forest_dragon", "actives", "hunter"}, key = "hunterDamageBonus", comment = "The damage bonus the hunter effect gives when invisible. This value is multiplied by the skill level." )
-	public static Double hunterDamageBonus = 1.5;
+	@ConfigOption( side = ConfigSide.SERVER, category = {"magic", "abilities", "forest_dragon", "actives", "hunter"}, key = "hunterDamageBonus", comment = "The bonus damage multiplier the hunter effect gives when invisible. This value is multiplied by the skill level." )
+	public static Double hunterDamageBonus = 1.0;
 
 	@ConfigRange( min = 0, max = 100 )
 	@ConfigOption( side = ConfigSide.SERVER, category = {"magic", "abilities", "forest_dragon", "actives", "hunter"}, key = "hunterManaCost", comment = "The mana cost for using the hunter ability" )

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
@@ -123,7 +123,7 @@ public class HunterAbility extends ChargeCastAbility{
 
 	@Override
 	public Component getDescription(){
-		return Component.translatable("ds.skill.description." + getName(), 1.5 * getLevel() + "x", getDuration());
+		return Component.translatable("ds.skill.description." + getName(), hunterDamageBonus * getLevel() + "x", getDuration());
 	}
 
 	@Override

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/abilities/ForestDragon/active/HunterAbility.java
@@ -123,7 +123,7 @@ public class HunterAbility extends ChargeCastAbility{
 
 	@Override
 	public Component getDescription(){
-		return Component.translatable("ds.skill.description." + getName(), hunterDamageBonus * getLevel() + "x", getDuration());
+		return Component.translatable("ds.skill.description." + getName(), "+" + hunterDamageBonus * getLevel() + "x", getDuration());
 	}
 
 	@Override

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
@@ -119,7 +119,6 @@ public class DragonModifiers{
 		if(!ServerConfig.bonuses) {
 			return;
 		}
-		System.out.println("Setting attack range bonus to " + mod + ".");
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get()));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);
@@ -141,7 +140,6 @@ public class DragonModifiers{
 		if(!ServerConfig.bonuses || !ServerConfig.attackDamage){
 			return;
 		}
-		System.out.println("Setting attack damage bonus to " + mod + ".");
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(Attributes.ATTACK_DAMAGE));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
@@ -22,6 +22,7 @@ public class DragonModifiers{
 	public static final UUID HEALTH_MODIFIER_UUID = UUID.fromString("03574e62-f9e4-4f1b-85ad-fde00915e446");
 	public static final UUID DAMAGE_MODIFIER_UUID = UUID.fromString("5bd3cebc-132e-4f9d-88ef-b686c7ad1e2c");
 	public static final UUID SWIM_SPEED_MODIFIER_UUID = UUID.fromString("2a9341f3-d19e-446c-924b-7cf2e5259e10");
+	public static final UUID ATTACK_RANGE_MODIFIER_UUID = UUID.fromString("a2e9a028-4bef-48d4-a25b-9cfdcac99480");
 
 	public static AttributeModifier buildHealthMod(double size){
 		double healthMod = (float)ServerConfig.minHealth + (size - 14) / 26F * ((float)ServerConfig.maxHealth - (float)ServerConfig.minHealth) - 20;
@@ -35,6 +36,12 @@ public class DragonModifiers{
 		double reachMod = (size - DragonLevel.NEWBORN.size) / (60.0 - DragonLevel.NEWBORN.size) * ServerConfig.reachBonus;
 
 		return new AttributeModifier(REACH_MODIFIER_UUID, "Dragon Reach Adjustment", reachMod, Operation.MULTIPLY_BASE);
+	}
+	
+	public static AttributeModifier buildAttackRangeMod(double size) {
+		double rangeMod = (size - DragonLevel.NEWBORN.size) / (60.0 - DragonLevel.NEWBORN.size) * ServerConfig.attackRangeBonus;
+		
+		return new AttributeModifier(ATTACK_RANGE_MODIFIER_UUID, "Dragon Attack Range Adjustment", rangeMod, Operation.MULTIPLY_BASE);
 	}
 
 	public static AttributeModifier buildDamageMod(DragonStateHandler handler, boolean isDragon){
@@ -68,6 +75,10 @@ public class DragonModifiers{
 		if(oldMod != null){
 			updateReachModifier(newPlayer, oldMod);
 		}
+		oldMod = getAttackRangeModifier(oldPlayer);
+		if (oldMod != null){
+			updateAttackRangeModifier(newPlayer, oldMod);
+		}
 	}
 
 	@Nullable
@@ -89,12 +100,27 @@ public class DragonModifiers{
 	public static AttributeModifier getSwimSpeedModifier(Player player){
 		return Objects.requireNonNull(player.getAttribute(ForgeMod.SWIM_SPEED.get())).getModifier(SWIM_SPEED_MODIFIER_UUID);
 	}
+	
+	@Nullable
+	public static AttributeModifier getAttackRangeModifier(Player player) {
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get())).getModifier(ATTACK_RANGE_MODIFIER_UUID);
+	}
 
 	public static void updateReachModifier(Player player, AttributeModifier mod){
 		if(!ServerConfig.bonuses){
 			return;
 		}
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.REACH_DISTANCE.get()));
+		max.removeModifier(mod);
+		max.addPermanentModifier(mod);
+	}
+	
+	public static void updateAttackRangeModifier(Player player, AttributeModifier mod) {
+		if(!ServerConfig.bonuses) {
+			return;
+		}
+		System.out.println("Setting attack range bonus to " + mod + ".");
+		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get()));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);
 	}
@@ -115,6 +141,7 @@ public class DragonModifiers{
 		if(!ServerConfig.bonuses || !ServerConfig.attackDamage){
 			return;
 		}
+		System.out.println("Setting attack damage bonus to " + mod + ".");
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(Attributes.ATTACK_DAMAGE));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);


### PR DESCRIPTION
### ServerConfig.java
- Added config option to modify attack range based on dragon size
- Uses the same calculation as block reach for bonus multiplier

### DragonStateHandler.java
- Attack range modifier handling

### DragonModifiers.java
- Functions for attack range modifier

### MagicHandler.java
**Hunter (Forest Dragon)**
- Before: level 1 overwrote critical hits to deal 1.5x damage, level 2 overwrote critical hits to do 3.0x damage
- Now: level 1 will now apply a 2.0x damage bonus, and level 2 will apply a 3.0x damage bonus, additive to any critical hit modifiers
- Vanilla critical hits add 0.5x damage, so a critical hit with level 1 Hunter will do 2.5x damage and level 2 will be 3.5x

### HunterAbility.java
- Changed the default value of hunterDamageBonus from 1.5 to 1.0
- Updated tooltip