### PR TITLE
pose stack bandaid fix

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ClientConfig.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ClientConfig.java
@@ -24,4 +24,7 @@ public class ClientConfig{
 
 	@ConfigOption(side = ConfigSide.CLIENT, category = "misc", key = "stableNightVision", comment = "When enabled it stops the blinking effect of night vision when low duration, disable if it causes rendering issues with other mods.")
 	public static Boolean stableNightVision = true;
+
+	@ConfigOption(side = ConfigSide.CLIENT, category = "misc", key = "emptyPoseStack", comment = "A fallback option in case the mod crashes with \"Pose stack not empty\". This could cause visual rendering problems.")
+	public static Boolean emptyPoseStack = false;
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/MixinLevelRenderer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/MixinLevelRenderer.java
@@ -1,0 +1,47 @@
+package by.dragonsurvivalteam.dragonsurvival.mixins;
+
+import by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod;
+import by.dragonsurvivalteam.dragonsurvival.config.ClientConfig;
+import by.dragonsurvivalteam.dragonsurvival.util.Functions;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LevelRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LevelRenderer.class)
+public class MixinLevelRenderer {
+    @Unique private int dragonSurvival$lastLog;
+
+    @Inject(method = "checkPoseStack", at = @At("HEAD"))
+    private void clearPoseStack(final PoseStack poseStack, final CallbackInfo callback) {
+        if (!ClientConfig.emptyPoseStack) {
+            return;
+        }
+
+        // To make sure the size is at least 1
+        poseStack.pushPose();
+
+        int popped = -1;
+
+        while (!poseStack.clear()) {
+            poseStack.popPose();
+            popped++;
+        }
+
+        if (Minecraft.getInstance().player != null) {
+            if (Minecraft.getInstance().player.tickCount - dragonSurvival$lastLog > Functions.secondsToTicks(30)) {
+                if (popped == -1) {
+                    DragonSurvivalMod.LOGGER.warn("Pose stack had no elements");
+                } else if (popped > 0) {
+                    DragonSurvivalMod.LOGGER.warn("Pose stack had [{}] additional stacks", popped);
+                }
+
+                dragonSurvival$lastLog = Minecraft.getInstance().player.tickCount;
+            }
+        }
+    }
+}

--- a/src/main/resources/dragonsurvival.mixins.json
+++ b/src/main/resources/dragonsurvival.mixins.json
@@ -16,6 +16,7 @@
     "MixinPlayerEnd",
     "MixinServerPlayerGameMode",
     "MixinSleepStatus",
+    "MixinLevelRenderer",
     "tool_swap.MixinServerPlayerGameModeStart",
     "tool_swap.MixinServerPlayerGameModeEnd"
   ],


### PR DESCRIPTION
for problems like #407

if the client config is enabled and the pose stack is faulty then it could lead to visual errors
(but at least it shouldn't crash)