### PR TITLE
Configurable break speed bonus

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
@@ -242,6 +242,22 @@ public class ServerConfig{
 	@ConfigOption( side = ConfigSide.SERVER, category = "bonuses", key = "bonusHarvestLevel", comment = "The harvest level to apply to a dragons specific tool type once unlocked." )
 	public static Integer bonusHarvestLevel = 1;
 
+	@ConfigRange(min = 1, max = 10)
+	@ConfigOption(side = ConfigSide.SERVER, category = "bonuses", key = "bonusBreakSpeed", comment = "Bonus break speed against blocks which are effective for the dragon type (break speed * bonus) - only applied if the bonus is unlocked")
+	public static Float bonusBreakSpeed = 2f;
+
+	@ConfigRange(min = 1, max = 10)
+	@ConfigOption(side = ConfigSide.SERVER, category = "bonuses", key = "bonusBreakSpeedAdult", comment = "Bonus break speed against blocks which are effective for the dragon type (break speed * bonus) - only applied if the bonus is unlocked and the dragon is fully grown")
+	public static Float bonusBreakSpeedAdult = 2.5f;
+
+	@ConfigRange(min = 1, max = 10)
+	@ConfigOption(side = ConfigSide.SERVER, category = "bonuses", key = "baseBreakSpeedAdult", comment = "Bonus break speed against all blocks (break speed * bonus) - only applied if the dragon is fully grown (unlocked bonus value will overwrite this one for effective blocks)")
+	public static Float baseBreakSpeedAdult = 1.5f;
+
+	@ConfigRange(min = 1, max = 10)
+	@ConfigOption(side = ConfigSide.SERVER, category = "bonuses", key = "bonusBreakSpeedReduction", comment = "Value the bonus will be divided by if an effective claw tool is present for the block")
+	public static Float bonusBreakSpeedReduction = 2f;
+
 	@ConfigOption( side = ConfigSide.SERVER, category = "bonuses", key = "bonusUnlockedAt", comment = "The stage that dragons unlock the bonus harvest level." )
 	public static DragonLevel bonusUnlockedAt = DragonLevel.YOUNG;
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/containers/DragonContainer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/containers/DragonContainer.java
@@ -1,6 +1,7 @@
 package by.dragonsurvivalteam.dragonsurvival.server.containers;
 
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.common.capability.subcapabilities.ClawInventory;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSContainers;
 import by.dragonsurvivalteam.dragonsurvival.server.containers.slots.ClawToolSlot;
 import by.dragonsurvivalteam.dragonsurvival.util.ToolUtils;
@@ -121,7 +122,7 @@ public class DragonContainer extends AbstractContainerMenu {
 
 		// Claw tool slots
 		DragonStateProvider.getCap(player).ifPresent(handler -> {
-			for (int i = 0; i < 4; i++) {
+			for (int i = 0; i < ClawInventory.Slot.size(); i++) {
 				ClawToolSlot clawToolSlot = new ClawToolSlot(this, handler.getClawToolData().getClawsInventory(), i, -50, 35 + i * 18, i);
 				addSlot(clawToolSlot);
 				inventorySlots.add(clawToolSlot);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/containers/slots/ClawToolSlot.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/containers/slots/ClawToolSlot.java
@@ -2,6 +2,7 @@ package by.dragonsurvivalteam.dragonsurvival.server.containers.slots;
 
 import by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
+import by.dragonsurvivalteam.dragonsurvival.common.capability.subcapabilities.ClawInventory;
 import by.dragonsurvivalteam.dragonsurvival.network.NetworkHandler;
 import by.dragonsurvivalteam.dragonsurvival.network.claw.SyncDragonClawsMenu;
 import by.dragonsurvivalteam.dragonsurvival.server.containers.DragonContainer;
@@ -34,13 +35,12 @@ public class ClawToolSlot extends Slot {
 
 	@Override
 	public boolean mayPlace(@NotNull final ItemStack itemStack) {
-		return switch(clawSlot) {
-			case 0 -> ToolUtils.isWeapon(itemStack);
-			case 1 -> ToolUtils.isPickaxe(itemStack);
-			case 2 -> ToolUtils.isAxe(itemStack);
-			case 3 -> ToolUtils.isShovel(itemStack);
-			default -> false;
-		};
+		return switch(ClawInventory.Slot.values()[clawSlot]) {
+			case SWORD -> ToolUtils.isWeapon(itemStack);
+			case PICKAXE -> ToolUtils.isPickaxe(itemStack);
+			case AXE -> ToolUtils.isAxe(itemStack);
+			case SHOVEL -> ToolUtils.isShovel(itemStack);
+        };
 	}
 
 	@Override


### PR DESCRIPTION
- if bonus is unlocked: multiplier of 2
- if bonus is unlocked and adult stage: multiplier of 2.5
- adult stage default bonus against all blocks: 1.5 (unlocked bonus will be used for effective blocks)

bonus will be divided by 2 if a relevant tool is in the claw slot
meaning the break speed bonus will only apply in those cases for adult stage dragons (multiplier of 1.25)
(bonus will always be at least 1 so this cannot cause a reduction in break speed)

meaning with this stone will no longer insta-break with an unenchanted netherite pickaxe in the claw slot