### PR TITLE
Added significantly better support for dragons larger than the default size. Ported my changes down from 1.20.1.

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -5,6 +5,7 @@ import by.dragonsurvivalteam.dragonsurvival.client.render.ClientDragonRender;
 import by.dragonsurvivalteam.dragonsurvival.client.sounds.FastGlideSound;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigOption;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigRange;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigSide;
@@ -148,6 +149,17 @@ public class ClientFlightHandler {
 					if(flightZoomEffect){
 						lastZoom = Mth.lerp(0.25f, lastZoom, 1f);
 						gameRenderer.setZoom(lastZoom);
+					}
+				}
+
+
+				// Move the third person camera into a more suitable position if the player is too large (otherwise it ends up clipping inside the player)
+				if(setup.getCamera().isDetached()) {
+					if(dragonStateHandler.isDragon() && dragonStateHandler.getSize() > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+						// I'm not entirely sure why 20 works here, but it seems to be the magic number that
+						// keeps the dragon's size from the camera's perspective constant.
+						double offset = (dragonStateHandler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / 20;
+						info.move(-offset, 0, 0);
 					}
 				}
 			}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
@@ -14,6 +14,7 @@ import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.AbstractDragonTy
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.DragonTypes;
 import by.dragonsurvivalteam.dragonsurvival.common.entity.DragonEntity;
 import by.dragonsurvivalteam.dragonsurvival.config.ClientConfig;
+import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigOption;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigSide;
 import by.dragonsurvivalteam.dragonsurvival.magic.DragonAbilities;
@@ -269,9 +270,19 @@ public class ClientDragonRender{
 				if(player.isCrouching() && handler.isWingsSpread() && !player.isOnGround()){
 					matrixStack.translate(0, -0.15, 0);
 				}else if(player.isCrouching()){
-					matrixStack.translate(0, 0.325 - size / DragonLevel.ADULT.size * 0.140, 0);
+					if(size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+						matrixStack.translate(0, 0.045, 0);
+					}
+					else {
+						matrixStack.translate(0, 0.325 - size / DragonLevel.ADULT.size * 0.140, 0);
+					}
 				}else if(player.isSwimming() || player.isAutoSpinAttack() || handler.isWingsSpread() && !player.isOnGround() && !player.isInWater() && !player.isInLava()){
- 					matrixStack.translate(0, -0.15 - size / DragonLevel.ADULT.size * 0.2, 0);
+					if(size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+						matrixStack.translate(0, -0.55, 0);
+					}
+					else {
+						matrixStack.translate(0, -0.15 - size / DragonLevel.ADULT.size * 0.2, 0);
+					}
 				}
 				if(!player.isInvisible()){
 					if(ServerFlightHandler.isGliding(player)){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonConfigHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonConfigHandler.java
@@ -25,6 +25,7 @@ public class DragonConfigHandler{
 	public static List<Item> SEA_DRAGON_HYDRATION_USE_ALTERNATIVES = List.of();
 
 	public static List<Block> FOREST_DRAGON_BREATH_GROW_BLACKLIST = List.of();
+	public static List<Block> DRAGON_DESTRUCTIBLE_BLOCKS = List.of();
 
 	public static Map<String, List<Block>> DRAGON_SPEEDUP_BLOCKS;
 	public static Map<String, List<Block>> DRAGON_BREATH_BLOCKS;
@@ -49,6 +50,7 @@ public class DragonConfigHandler{
 			rebuildBreathBlocks();
 			rebuildManaBlocks();
 			rebuildForestDragonConfigs();
+			rebuildDestructibleBlocks();
 		}
 	}
 
@@ -83,5 +85,9 @@ public class DragonConfigHandler{
 
 	public static void rebuildForestDragonConfigs(){
 		FOREST_DRAGON_BREATH_GROW_BLACKLIST = ConfigHandler.getResourceElements(Block.class, ForestBreathAbility.forestBreathGrowBlacklist);
+	}
+
+	public static void rebuildDestructibleBlocks(){
+		DRAGON_DESTRUCTIBLE_BLOCKS = ConfigHandler.getResourceElements(Block.class, ServerConfig.destructibleBlocks);
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 
 public class ServerConfig{
+	public static final Double DEFAULT_MAX_GROWTH_SIZE = 60.0;
 	ServerConfig(Builder builder){
 		ConfigHandler.addConfigs(builder, ConfigSide.SERVER);
 	}
@@ -49,6 +50,64 @@ public class ServerConfig{
 	public static Boolean startWithDragonChoice = true;
 
 	// Growth
+	@ConfigType(Block.class)
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "destructibleBlocks", comment = "Blocks that are destructible when block destruction is enabled. Blocks that can be harvested with an axe are also destroyable by default on whitelist mode. Formatting: block/modid:id" )
+	public static List<String> destructibleBlocks = List.of(
+			"minecraft:leaves"
+	);
+
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "useBlacklistForDestructibleBlocks", comment = "Use a blacklist for destructible blocks instead of a whitelist.")
+	public static Boolean useBlacklistForDestructibleBlocks = false;
+
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "allowLargeBlockDestruction", comment = "Allow a dragon to instantly destroy certain colliding blocks if they are above a certain size.")
+	public static Boolean allowLargeBlockDestruction = false;
+
+	@ConfigRange( min = 0.0, max = 1.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeBlockDestructionRemovePercentage", comment = "The percentage of blocks removed instead of destroyed when a dragon instantly destroys blocks. If a block is removed, it doesn't make a sound or particle effect. This is to minimize lag from particle VFX and audio spam.")
+	public static Double largeBlockDestructionRemovePercentage = 0.96;
+
+	@ConfigRange( min = 14.0, max = 1000000.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeBlockDestructionSize", comment = "The size threshold for a dragon to start instantly destroying blocks. Crouching prevents destruction from occurring.")
+	public static Double largeBlockDestructionSize = 120.0;
+
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "allowCrushing", comment = "Allow a dragon to crush entities beneath it after being above a certain size. Crouching prevents crushing from occurring.")
+	public static Boolean allowCrushing = false;
+
+	@ConfigRange( min = 14.0, max = 1000000.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "crushingSize", comment = "The size at which a dragon can begin to crush entities.")
+	public static Double crushingSize = 120.0;
+
+	@ConfigRange( min = 0.0, max = 20.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "crushingDamageScalar", comment = "The amount damage dealt per dragon size when crushing entities.")
+	public static Double crushingDamageScalar = 0.05;
+
+	@ConfigRange( min = 0, max = 20 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "crushingSize", comment = "The amount of ticks before entities can be crushed again after they were already crushed.")
+	public static Integer crushingTickDelay = 20;
+
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "allowLargeScaling", comment = "Allow a dragon's max health, damage, reach, and step height to continue to scale with growth beyond its normal limits.")
+	public static Boolean allowLargeScaling = false;
+
+	@ConfigRange( min = 1, max = 1000 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeMaxHealth", comment = "The maximum health when the dragon is at maximum growth size if large scaling is enabled.")
+	public static Integer largeMaxHealth = 80;
+
+	@ConfigRange( min = 0.0, max = 100.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeDamageBonus", comment = "The bonus damage when the dragon is at maximum growth size if large scaling is enabled.")
+	public static Double largeDamageBonus = 6.0;
+
+	@ConfigRange( min = 0.0, max = 100.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeReachScalar", comment = "The bonus reach given per 60 size once the dragon is above the default growth size of 60 if large scaling is enabled.")
+	public static Double largeReachScalar = 0.5;
+
+	@ConfigRange( min = 0.0, max = 100.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeStepHeightScalar", comment = "The bonus step height given per 60 size once the dragon is above the default growth size of 60 if large scaling is enabled.")
+	public static Double largeStepHeightScalar = 1.0;
+
+	@ConfigRange( min = 0.0, max = 10.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "largeBlockBreakRadiusScalar", comment = "The bonus block break radius given per 60 size once the dragon is above the default growth size of 60 if large scaling is enabled. A block radius of 0 disables this feature. Crouching allows you to mine one block at a time.")
+	public static Double largeBlockBreakRadiusScalar = 0.7;
+
 	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "sizeChangesHitbox", comment = "Whether the dragon size determines its hitbox size. The bigger the dragon, the bigger the hitbox. If false standard player's hitbox be used." )
 	public static Boolean sizeChangesHitbox = true;
 
@@ -72,10 +131,10 @@ public class ServerConfig{
 
 	@ConfigRange( min = 14.0, max = 1000000.0 )
 	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "maxGrowthSize", comment = "Defines the max size your dragon can grow to. Values that are too high can break your game. It is not advisable to set a number higher than 60." )
-	public static Double maxGrowthSize = 60.0;
+	public static Double maxGrowthSize = DEFAULT_MAX_GROWTH_SIZE;
 
 	@ConfigRange( min = 0, max = 1000000.0 )
-	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "reachBonus", comment = "The bonus that is given to dragons at every 60 size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default value. Only applies to block mining." )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "reachBonus", comment = "The bonus that is given to dragons at 60 size. The bonus gradually scales up to the maximum size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default values.")
 	public static Double reachBonus = 0.5;
 	
 	@ConfigRange( min = 0, max = 1000000.0 )
@@ -90,8 +149,12 @@ public class ServerConfig{
 	public static Integer minHealth = 14;
 
 	@ConfigRange( min = 1, max = 100 )
-	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "maxHealth", comment = "Maximum health dragons can grow to." )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "maxHealth", comment = "The maximum health when the dragon is fully grown." )
 	public static Integer maxHealth = 40;
+
+	@ConfigRange( min = 1, max = 100 )
+	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "maxHealthSize", comment = "The size at which the maximum health is reached." )
+	public static Integer maxHealthSize = 40;
 
 	@ConfigRange( min = 0.0, max = 1000 )
 	@ConfigOption( side = ConfigSide.SERVER, category = "growth", key = "newbornGrowthModifier", comment = "A multiplier to change the growth rate from newborn to young. At 1.0 it takes about 3 hours to turn a newborn dragon into a young dragon." )

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DamageSources.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DamageSources.java
@@ -7,4 +7,5 @@ public class DamageSources{
 	public static final DamageSource WATER_BURN = new DamageSource("waterBurn").bypassArmor();
 	public static final DamageSource RAIN_BURN = new DamageSource("rainBurn").bypassArmor();
 	public static final DamageSource DEHYDRATION = new DamageSource("dehydration").bypassArmor();
+	public static final DamageSource CRUSHED = new DamageSource("crushed");
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
@@ -6,6 +6,7 @@ import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.DragonTypes;
 import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
@@ -23,35 +24,62 @@ public class DragonModifiers{
 	public static final UUID DAMAGE_MODIFIER_UUID = UUID.fromString("5bd3cebc-132e-4f9d-88ef-b686c7ad1e2c");
 	public static final UUID SWIM_SPEED_MODIFIER_UUID = UUID.fromString("2a9341f3-d19e-446c-924b-7cf2e5259e10");
 	public static final UUID ATTACK_RANGE_MODIFIER_UUID = UUID.fromString("a2e9a028-4bef-48d4-a25b-9cfdcac99480");
+	public static final UUID STEP_HEIGHT_MODIFIER_UUID = UUID.fromString("f3b0b3e3-3b7d-4b1b-8f3d-3b7d4b1b8f3d");
 
 	public static AttributeModifier buildHealthMod(double size){
-		double healthMod = (float)ServerConfig.minHealth + (size - 14) / 26F * ((float)ServerConfig.maxHealth - (float)ServerConfig.minHealth) - 20;
-		healthMod = Math.min(healthMod, ServerConfig.maxHealth - 20);
-
-
-		return new AttributeModifier(HEALTH_MODIFIER_UUID, "Dragon Health Adjustment", healthMod, AttributeModifier.Operation.ADDITION);
+		double healthModifier;
+		if(ServerConfig.allowLargeScaling && size > ServerConfig.maxHealthSize) {
+			double healthModifierPercentage = Math.max(1.0, (size - ServerConfig.maxHealthSize) / (ServerConfig.maxGrowthSize - DragonLevel.ADULT.size));
+			healthModifier = Mth.lerp(healthModifierPercentage, ServerConfig.maxHealth, ServerConfig.largeMaxHealth) - 20;
+		}
+		else {
+			double healthModifierPercentage = Math.max(1.0, (size - DragonLevel.NEWBORN.size) / (ServerConfig.maxHealthSize - DragonLevel.NEWBORN.size));
+			healthModifier = Mth.lerp(healthModifierPercentage, ServerConfig.minHealth, ServerConfig.maxHealth) - 20;
+		}
+		return new AttributeModifier(HEALTH_MODIFIER_UUID, "Dragon Health Adjustment", healthModifier, AttributeModifier.Operation.ADDITION);
 	}
 
 	public static AttributeModifier buildReachMod(double size){
-		double reachMod = (size - DragonLevel.NEWBORN.size) / (60.0 - DragonLevel.NEWBORN.size) * ServerConfig.reachBonus;
-
-		return new AttributeModifier(REACH_MODIFIER_UUID, "Dragon Reach Adjustment", reachMod, Operation.MULTIPLY_BASE);
+		double reachModifier;
+		if(ServerConfig.allowLargeScaling && size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+			reachModifier = ServerConfig.reachBonus + ServerConfig.largeReachScalar * (size / ServerConfig.DEFAULT_MAX_GROWTH_SIZE);
+		}
+		else {
+			reachModifier = Math.max(ServerConfig.reachBonus, (size - DragonLevel.NEWBORN.size) / (ServerConfig.DEFAULT_MAX_GROWTH_SIZE - DragonLevel.NEWBORN.size) * ServerConfig.reachBonus);
+		}
+		return new AttributeModifier(REACH_MODIFIER_UUID, "Dragon Reach Adjustment", reachModifier, Operation.MULTIPLY_BASE);
 	}
 	
 	public static AttributeModifier buildAttackRangeMod(double size) {
-		double rangeMod = (size - DragonLevel.NEWBORN.size) / (60.0 - DragonLevel.NEWBORN.size) * ServerConfig.attackRangeBonus;
-		
+		double rangeMod;
+		if(ServerConfig.allowLargeScaling && size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+			rangeMod = ServerConfig.attackRangeBonus + ServerConfig.largeReachScalar * (size / ServerConfig.DEFAULT_MAX_GROWTH_SIZE);
+		}
+		else {
+			rangeMod = Math.max(ServerConfig.attackRangeBonus, (size - DragonLevel.NEWBORN.size) / (ServerConfig.DEFAULT_MAX_GROWTH_SIZE - DragonLevel.NEWBORN.size) * ServerConfig.attackRangeBonus);
+		}
 		return new AttributeModifier(ATTACK_RANGE_MODIFIER_UUID, "Dragon Attack Range Adjustment", rangeMod, Operation.MULTIPLY_BASE);
 	}
 
 	public static AttributeModifier buildDamageMod(DragonStateHandler handler, boolean isDragon){
 		double ageBonus = isDragon ? handler.getLevel() == DragonLevel.ADULT ? ServerConfig.adultBonusDamage : handler.getLevel() == DragonLevel.YOUNG ? ServerConfig.youngBonusDamage : ServerConfig.babyBonusDamage : 0;
-
+		if(ServerConfig.allowLargeScaling && handler.getSize() > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+			double damageModPercentage = Math.max(1.0, (handler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / (ServerConfig.maxGrowthSize - ServerConfig.DEFAULT_MAX_GROWTH_SIZE));
+			ageBonus = Mth.lerp(damageModPercentage, ageBonus, ServerConfig.largeDamageBonus);
+		}
 		return new AttributeModifier(DAMAGE_MODIFIER_UUID, "Dragon Damage Adjustment", ageBonus, Operation.ADDITION);
 	}
 
 	public static AttributeModifier buildSwimSpeedMod(AbstractDragonType dragonType){
 		return new AttributeModifier(SWIM_SPEED_MODIFIER_UUID, "Dragon Swim Speed Adjustment", Objects.equals(dragonType, DragonTypes.SEA) && ServerConfig.seaSwimmingBonuses ? 1 : 0, Operation.ADDITION);
+	}
+
+	public static AttributeModifier buildStepHeightMod(double size) {
+		double stepHeightBonus = 0;
+		if(size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE && ServerConfig.allowLargeScaling)  {
+			stepHeightBonus = ServerConfig.largeStepHeightScalar * (size - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
+		}
+		return new AttributeModifier(STEP_HEIGHT_MODIFIER_UUID, "Dragon Step Height Adjustment", stepHeightBonus, Operation.ADDITION);
 	}
 
 	public static void updateModifiers(Player oldPlayer, Player newPlayer){
@@ -79,6 +107,10 @@ public class DragonModifiers{
 		if (oldMod != null){
 			updateAttackRangeModifier(newPlayer, oldMod);
 		}
+		oldMod = getStepHeightModifier(oldPlayer);
+		if (oldMod != null){
+			updateStepHeightModifier(newPlayer, oldMod);
+		}
 	}
 
 	@Nullable
@@ -104,6 +136,11 @@ public class DragonModifiers{
 	@Nullable
 	public static AttributeModifier getAttackRangeModifier(Player player) {
 		return Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get())).getModifier(ATTACK_RANGE_MODIFIER_UUID);
+	}
+
+	@Nullable
+	public static AttributeModifier getStepHeightModifier(Player player) {
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get())).getModifier(STEP_HEIGHT_MODIFIER_UUID);
 	}
 
 	public static void updateReachModifier(Player player, AttributeModifier mod){
@@ -150,6 +187,15 @@ public class DragonModifiers{
 			return;
 		}
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.SWIM_SPEED.get()));
+		max.removeModifier(mod);
+		max.addPermanentModifier(mod);
+	}
+
+	public static void updateStepHeightModifier(Player player, AttributeModifier mod) {
+		if(!ServerConfig.bonuses) {
+			return;
+		}
+		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get()));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/DragonDestructionHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/DragonDestructionHandler.java
@@ -1,0 +1,205 @@
+package by.dragonsurvivalteam.dragonsurvival.server.handlers;
+
+import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
+import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.common.handlers.DragonSizeHandler;
+import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
+import by.dragonsurvivalteam.dragonsurvival.registry.DamageSources;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec2;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import static by.dragonsurvivalteam.dragonsurvival.common.handlers.DragonConfigHandler.DRAGON_DESTRUCTIBLE_BLOCKS;
+
+@Mod.EventBusSubscriber
+public class DragonDestructionHandler {
+
+    private static int crushTickCounter = 0;
+    private static boolean isBreakingMultipleBlocks = false;
+
+    private static void checkAndDestroyCollidingBlocks(DragonStateHandler dragonStateHandler, TickEvent.PlayerTickEvent event, AABB boundingBox) {
+        if(!ServerConfig.allowLargeBlockDestruction) {
+            return;
+        }
+
+        if(ServerConfig.largeBlockDestructionSize > dragonStateHandler.getSize()) {
+            return;
+        }
+
+        // Copied from checkWalls in EnderDragon.java
+        int i = Mth.floor(boundingBox.minX);
+        int j = Mth.floor(boundingBox.minY);
+        int k = Mth.floor(boundingBox.minZ);
+        int l = Mth.ceil(boundingBox.maxX);
+        int i1 = Mth.ceil(boundingBox.maxY);
+        int j1 = Mth.ceil(boundingBox.maxZ);
+
+        RandomSource random = new XoroshiroRandomSource(event.player.level.getGameTime());
+
+        for (int k1 = i; k1 <= l; ++k1) {
+            for (int l1 = j; l1 <= i1; ++l1) {
+                for (int i2 = k; i2 <= j1; ++i2) {
+                    BlockPos blockpos = new BlockPos(k1, l1, i2);
+                    BlockState blockstate = event.player.level.getBlockState(blockpos);
+                    if (!blockstate.isAir()) {
+                        if(ServerConfig.useBlacklistForDestructibleBlocks) {
+                            if(!DRAGON_DESTRUCTIBLE_BLOCKS.contains(blockstate.getBlock())) {
+                                if(random.nextFloat() > ServerConfig.largeBlockDestructionRemovePercentage) {
+                                    event.player.level.destroyBlock(blockpos, false);
+                                }
+                                else {
+                                    event.player.level.removeBlock(blockpos, false);
+                                }
+                            }
+                        }
+                        else {
+                            // #TODO: Make the MINEABLE_WITH_AXE, FLOWERS and REPLACEABLE_PLANTS tag configurable in data
+                            if(DRAGON_DESTRUCTIBLE_BLOCKS.contains(blockstate.getBlock()) || blockstate.is(BlockTags.REPLACEABLE_PLANTS) || blockstate.is(BlockTags.MINEABLE_WITH_AXE) || blockstate.is(BlockTags.FLOWERS)) {
+                                if(random.nextFloat() > ServerConfig.largeBlockDestructionRemovePercentage) {
+                                    event.player.level.destroyBlock(blockpos, false);
+                                }
+                                else {
+                                    event.player.level.removeBlock(blockpos, false);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void checkAndDamageCrushedEntities(DragonStateHandler dragonStateHandler, ServerPlayer player, AABB boundingBox) {
+        if(!ServerConfig.allowCrushing) {
+            return;
+        }
+
+        if(ServerConfig.crushingSize > dragonStateHandler.getSize()) {
+            return;
+        }
+
+        if(--crushTickCounter > 0) {
+            return;
+        }
+
+        // Get only the bounding box of the player's feet (estimate by using only the bottom 1/3 of the bounding box)
+        AABB feetBoundingBox = new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY - (boundingBox.maxY - boundingBox.minY) / 3.0, boundingBox.maxZ);
+
+        for(var entity : player.level.getNearbyEntities(LivingEntity.class, TargetingConditions.DEFAULT, player, feetBoundingBox)){
+            // If the entity being crushed is too big, don't damage it.
+            if(entity.getBoundingBox().getSize() > boundingBox.getSize() / 2.0f) {
+                continue;
+            }
+
+            entity.hurt(DamageSources.CRUSHED, (float)(dragonStateHandler.getSize() * ServerConfig.crushingDamageScalar));
+            crushTickCounter = ServerConfig.crushingTickDelay;
+        }
+    }
+
+    @SubscribeEvent
+    public static void destroyBlocksInRadius(BlockEvent.BreakEvent event)
+    {
+        if(isBreakingMultipleBlocks) {
+            return;
+        }
+
+        if(!ServerConfig.allowLargeScaling) {
+            return;
+        }
+
+        if(ServerConfig.largeBlockBreakRadiusScalar <= 0.0f) {
+            return;
+        }
+
+        if(!(event.getPlayer() instanceof ServerPlayer player)){
+            return;
+        }
+
+        if(player.isCrouching()) {
+            return;
+        }
+
+        DragonStateProvider.getCap(player).ifPresent(dragonStateHandler -> {
+            if(dragonStateHandler.isDragon()) {
+                if(dragonStateHandler.getSize() < ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+                    return;
+                }
+
+                isBreakingMultipleBlocks = true;
+
+                event.setCanceled(true);
+
+                // Break the blocks in a radius around the broken block
+                int radius = (int) Math.floor((dragonStateHandler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / 60.f * ServerConfig.largeBlockBreakRadiusScalar);
+                BlockPos pos = event.getPos();
+                for(int x = -radius; x <= radius; x++) {
+                    for(int y = -radius; y <= radius; y++) {
+                        for(int z = -radius; z <= radius; z++) {
+                            BlockPos newPos = pos.offset(x, y, z);
+                            player.gameMode.destroyBlock(newPos);
+                        }
+                    }
+                }
+
+                isBreakingMultipleBlocks = false;
+            }
+        });
+    }
+
+
+
+    @SubscribeEvent
+    public static void checkAndDestroyCollidingBlocks(TickEvent.PlayerTickEvent event) {
+        if(!ServerConfig.allowLargeBlockDestruction && !ServerConfig.allowCrushing) {
+            return;
+        }
+
+        if(!(event.player instanceof ServerPlayer player)){
+            return;
+        }
+
+        DragonStateProvider.getCap(player).ifPresent(dragonStateHandler -> {
+            if(dragonStateHandler.isDragon()) {
+
+                if(player.isCrouching()) {
+                    return;
+                }
+
+                Vec2 deltaXZ = new Vec2((float)player.getDeltaMovement().x, (float)player.getDeltaMovement().z);
+                if(deltaXZ.length() < 0.05f && Math.abs(player.getDeltaMovement().y) < 0.25f) {
+                    return;
+                }
+
+                AABB boundingBox;
+                if (ServerConfig.sizeChangesHitbox) {
+                    double size = dragonStateHandler.getSize();
+                    double height = DragonSizeHandler.calculateModifiedHeight(DragonSizeHandler.calculateDragonHeight(size, ServerConfig.hitboxGrowsPastHuman), event.player.getPose(), ServerConfig.sizeChangesHitbox);
+                    double width = DragonSizeHandler.calculateDragonWidth(size, ServerConfig.hitboxGrowsPastHuman) / 2.0D;
+                    boundingBox = DragonSizeHandler.calculateDimensions(width, height).makeBoundingBox(player.position());
+                } else {
+                    boundingBox = player.getBoundingBox();
+                }
+
+                boundingBox = boundingBox.inflate(1.25);
+
+                checkAndDestroyCollidingBlocks(dragonStateHandler, event, boundingBox);
+                checkAndDamageCrushedEntities(dragonStateHandler, player, boundingBox);
+            }
+        });
+    }
+}

--- a/src/main/resources/assets/dragonsurvival/lang/en_us.json
+++ b/src/main/resources/assets/dragonsurvival/lang/en_us.json
@@ -156,6 +156,8 @@
   "death.attack.rainBurn.player": "%1$s spent too much time in the rain trying to escape %2$s.",
   "death.attack.dehydration": "%1$s dried out.",
   "death.attack.dehydration.player": "%1$s dried out to escape %2$s.",
+  "death.attack.crushed": "%1$s was crushed.",
+  "death.attack.crushed.player": "%1$s was crushed by %2$s.",
   "ds.cave_dragon_choice": "In the depths of your soul the lava began to roar. You have become a §cCave dragon.§r",
   "ds.forest_dragon_choice": "You feel the need for raw meat and are covered in grass scales. You have chosen to be a §aForest dragon.§r",
   "ds.sea_dragon_choice": "The stormy sea and fishes beckon you. Now you are a §3Sea dragon.§r",


### PR DESCRIPTION
-Fixed the third person camera being broken when the player is too large
-Fixed the inventory camera being broken when the player is too large
-Fixed the crouching animation being broken when the player is too large
-Added several new config options to adjust various settings that relate to larger dragon sizes
-Added a new crushing feature that allows dragons above a certain size to crush entities beneath them
-Added a new block destruction feature that allows dragons above a certain size to destroy certain blocks given a white or blacklist
-Added a new multiblock mining feature that allows dragons above a certain size to destroy multiple blocks in a radius

All of these features are disabled by default in the configuration settings. The intent of this PR is that none of the gameplay with the default config settings should change in any way.