### PR TITLE
Stop trying to sync player data on login/respawn/dimension change. Only allow reading data from the server in those situations.

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
@@ -67,26 +67,18 @@ public class Capabilities{
 				NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new RequestClientData(handler.getType(), handler.getLevel()));
 				NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new SyncDragonClawsMenu(serverPlayer.getId(), handler.getClawToolData().isMenuOpen(), handler.getClawToolData().getClawsInventory()));
 			});
-
-			syncCapability(serverPlayer);
 		}
-	}
-
-	public static void syncCapability(final Player player) {
-		NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> player), new CompleteDataSync(player));
 	}
 
 	@SubscribeEvent
 	public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent playerRespawnEvent){
 		Player player = playerRespawnEvent.getEntity();
-		syncCapability(player);
 	}
 
 	@SubscribeEvent
 	public static void onDimensionChange(PlayerEvent.PlayerChangedDimensionEvent event){
 		// TODO :: Might not needed if EntityJoinLevelEvent is used instead of PlayerLoggedInEvent?
 		Player player = event.getEntity();
-		syncCapability(player);
 		DragonStateProvider.getCap(player).ifPresent(cap -> cap.getSkinData().compileSkin());
 	}
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerPlayerStatusSync.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerPlayerStatusSync.java
@@ -33,7 +33,6 @@ public class ServerPlayerStatusSync {
 				DragonStateHandler handler = DragonUtils.getHandler(player);
 				if(handler.lastSync == 0 || player.tickCount >= handler.lastSync + serverSyncTime){
 					handler.lastSync = player.tickCount;
-					NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY.with(() -> player), new CompleteDataSync(player.getId(), handler.writeNBT()));
 				}
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerPlayerStatusSync.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerPlayerStatusSync.java
@@ -18,11 +18,11 @@ import net.minecraftforge.network.PacketDistributor;
 @EventBusSubscriber
 public class ServerPlayerStatusSync {
 
-	@ConfigRange(min = -1, max = 60 * 60 * 20)
-	@ConfigOption( side = ConfigSide.SERVER, category = "general", key = "serverSyncTime", comment = "How often should player data be synced to other players? -1 disables it")
-	public static long serverSyncTime = 600;
+	// TLDR: This function is a failsafe that sync the player's data with the server after a certain period of time if it somehow gets out of sync.
 
-	@SubscribeEvent
+	// TODO: This function is removed for now, since it could potentially write to the player's NBT data before the player has read it.
+	// Once that is fixed, we should re-enable this function, but include some error reporting that says what went out of sync if the server and client data are not the same.
+	/*@SubscribeEvent
 	public static void onServerTick(PlayerTickEvent event){
 		if(event.side == LogicalSide.CLIENT || event.phase != Phase.START || serverSyncTime == -1) return;
 
@@ -36,5 +36,5 @@ public class ServerPlayerStatusSync {
 				}
 			}
 		}
-	}
+	}*/
 }


### PR DESCRIPTION
There is an underlying problem here where it is possible for the client to write data to the server before it has read data from the server. This should fix this situation in 99% of cases. However, it is still possible for the client to do an action that requires a sync after logging in but before receiving dragon data from the server, in which case their data will still get lost.

Would be a good idea to extend this fix in the future by explicitly checking if the player has read from the server (or is creating their dragon for the first time) before allowing any writes of dragon data to the server.

fixes #468 