### PR TITLE
Fixed skins being desynced. Reverted the change in onPlayerLoggedIn for now.

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/Capabilities.java
@@ -7,6 +7,7 @@ import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.network.NetworkHandler;
 import by.dragonsurvivalteam.dragonsurvival.network.RequestClientData;
 import by.dragonsurvivalteam.dragonsurvival.network.claw.SyncDragonClawsMenu;
+import by.dragonsurvivalteam.dragonsurvival.network.dragon_editor.SyncDragonSkinSettings;
 import by.dragonsurvivalteam.dragonsurvival.network.syncing.CompleteDataSync;
 import by.dragonsurvivalteam.dragonsurvival.registry.DragonEffects;
 import by.dragonsurvivalteam.dragonsurvival.registry.DragonModifiers;
@@ -23,6 +24,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.EntityLeaveLevelEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -67,8 +69,9 @@ public class Capabilities{
 				NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new RequestClientData(handler.getType(), handler.getBody(), handler.getLevel()));
 				NetworkHandler.CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new SyncDragonClawsMenu(serverPlayer.getId(), handler.getClawToolData().isMenuOpen(), handler.getClawToolData().getClawsInventory()));
 			});
+			// TODO: Investigate whether this call to syncCapability actually results in data loss under bad network conditions
+			syncCapability(serverPlayer);
 		}
-		// There used to be a call to syncCapability here, but doing so caused the client to receive the data before it was loaded, causing data loss.
 	}
 
 	public static void syncCapability(final Player player) {


### PR DESCRIPTION
It is possible the change to ServerPlayerStatusSync is still enough to prevent data loss, but am unsure.