### PR TITLE
Fixes desync based on server/client time mismatch

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/magic/ClientCastingHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/magic/ClientCastingHandler.java
@@ -55,7 +55,7 @@ public class ClientCastingHandler{
 			status = StatusIdle;
 			//System.out.println(player + " ability changed from " + ability.getName() + " to " + dragonStateHandler.getMagicData().getAbilityFromSlot(slot).getName() + ".");
 			if (castStartTime != -1 && ability.canCastSkill(player)) {
-				NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), true, castSlot, ability.saveNBT(), castStartTime));
+				NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), true, castSlot, ability.saveNBT(), castStartTime, player.level.getGameTime()));
 				//System.out.println(ability.getName() + " finished casting due to swap.");
 			}
 			hasCast = false;
@@ -83,9 +83,9 @@ public class ClientCastingHandler{
 		if(status == StatusInProgress && ability.canCastSkill(player) ){
 			if (castStartTime == -1)
 				castStartTime = player.level.getGameTime();
-			NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), true, castSlot, ability.saveNBT(), castStartTime));
+			NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), true, castSlot, ability.saveNBT(), castStartTime, player.level.getGameTime()));
 		} else if(status == StatusStop || status == StatusInProgress && !ability.canCastSkill(player) && castStartTime != -1){
-			NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), false, castSlot, ability.saveNBT(), castStartTime));
+			NetworkHandler.CHANNEL.sendToServer(new SyncAbilityCasting(player.getId(), false, castSlot, ability.saveNBT(), castStartTime, player.level.getGameTime()));
 			ability.onKeyReleased(player);
 			status = StatusIdle;
 			castStartTime = -1;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/entity/projectiles/BallLightningEntity.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/entity/projectiles/BallLightningEntity.java
@@ -1,6 +1,7 @@
 package by.dragonsurvivalteam.dragonsurvival.common.entity.projectiles;
 
 
+import by.dragonsurvivalteam.dragonsurvival.client.particles.DSParticles;
 import by.dragonsurvivalteam.dragonsurvival.client.particles.SeaDragon.LargeLightningParticleData;
 import by.dragonsurvivalteam.dragonsurvival.client.particles.SeaDragon.SmallLightningParticleData;
 import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
@@ -40,6 +41,7 @@ import java.util.List;
 public class BallLightningEntity extends DragonBallEntity{
 	protected boolean isLingering = false;
 	protected int lingerTicks = 100;
+	protected LargeLightningParticleData trail = new LargeLightningParticleData(37, false);
 	public BallLightningEntity(Level p_i50168_9_, LivingEntity p_i50168_2_, double p_i50168_3_, double p_i50168_5_, double p_i50168_7_){
 		super(DSEntities.BALL_LIGHTNING, p_i50168_2_, p_i50168_3_, p_i50168_5_, p_i50168_7_, p_i50168_9_);
 	}
@@ -50,7 +52,8 @@ public class BallLightningEntity extends DragonBallEntity{
 
 	@Override
 	protected ParticleOptions getTrailParticle(){
-		return ParticleTypes.WHITE_ASH;
+		//return ParticleTypes.WHITE_ASH;
+		return trail;
 		//plz, add here DSParticles.LARGE_LIGHTNING for cool effects, I cannot :(
 	}
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/DragonAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/DragonAbility.java
@@ -25,7 +25,7 @@ public abstract class DragonAbility { // FIXME :: dist
 		nf.setMaximumFractionDigits(1);
 	}
 
-	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime){}
+	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime, long clientTime){}
 	public void onKeyReleased(Player player){}
 
 	public Player getPlayer(){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/ChannelingCastAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/ChannelingCastAbility.java
@@ -18,28 +18,26 @@ public abstract class ChannelingCastAbility extends ActiveDragonAbility {
 	public long timeSinceStartChannel = -1;
 
 	@Override
-	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime){
-		long curTime = player.level.getGameTime();
-
-		chargeTime = (int) (curTime - castStartTime);
-		if(curTime - castStartTime >= getSkillChargeTime() && castStartTime != -1)
+	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime, long clientTime){
+		chargeTime = (int) (clientTime - castStartTime);
+		if(clientTime - castStartTime >= getSkillChargeTime() && castStartTime != -1)
 		{
-			timeSinceStartChannel = curTime - castStartTime - getSkillChargeTime();
+			timeSinceStartChannel = clientTime - castStartTime - getSkillChargeTime();
 			onChanneling(player, (int)(timeSinceStartChannel));
 			if (chargeTime < getSkillChargeTime())
 				chargeTime = getSkillChargeTime();
 
-			if (curTime - lastManaSpentTime >= getContinuousManaCostTime()) {
-				lastManaSpentTime = curTime;
+			if (clientTime - lastManaSpentTime >= getContinuousManaCostTime()) {
+				lastManaSpentTime = clientTime;
 				ManaHandler.consumeMana(player, getManaCost());
 			}
 		}else{
 			onCharging(player, chargeTime);
 
-			if(curTime - castStartTime >= getSkillChargeTime() / 2 && castStartTime != -1){
-				if (curTime - lastManaSpentTime >= getSkillChargeTime() / 2) {
+			if(clientTime - castStartTime >= getSkillChargeTime() / 2 && castStartTime != -1){
+				if (clientTime - lastManaSpentTime >= getSkillChargeTime() / 2) {
 					ManaHandler.consumeMana(player, getInitManaCost());
-					lastManaSpentTime = curTime;
+					lastManaSpentTime = clientTime;
 				}
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/ChargeCastAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/ChargeCastAbility.java
@@ -15,17 +15,16 @@ public abstract class ChargeCastAbility extends ActiveDragonAbility {
 	public abstract int getSkillCastingTime();
 	
 	@Override
-	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime){
+	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime, long clientTime){
 		if (castFinished)
 			return;
 
-		long curTime = player.level.getGameTime();
-		castTime = (int) (curTime - castStartTime);
+		castTime = (int) (clientTime - castStartTime);
 
 		if(castTime >= getSkillCastingTime() && castStartTime != -1 && !castFinished){
 			castingComplete(player);
 			startCooldown();
-			castStartTime = curTime;
+			castStartTime = clientTime;
 			castFinished = true;
 
 			ManaHandler.consumeMana(player, getManaCost());

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/InstantCastAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/active/InstantCastAbility.java
@@ -8,7 +8,7 @@ public abstract class InstantCastAbility extends ActiveDragonAbility {
 	public boolean castFinished = false;
 
 	@Override
-	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime){
+	public void onKeyPressed(Player player, Runnable onFinish, long castStartTime, long clientTime){
 		if (!castFinished) {
 			onCast(player);
 			ManaHandler.consumeMana(player, getManaCost());

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
@@ -206,7 +206,7 @@ public class ClientProxy {
                                 ClientCastingHandler.hasCast = true;
                                 ClientCastingHandler.status = ClientCastingHandler.StatusStop;
                             }
-                        }, message.castStartTime);
+                        }, message.castStartTime, message.clientTime);
                     } else {
                         ability.onKeyReleased(player);
                     }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/magic/SyncAbilityCasting.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/magic/SyncAbilityCasting.java
@@ -20,6 +20,7 @@ public class SyncAbilityCasting implements IMessage<SyncAbilityCasting> {
 	public int abilitySlot;
 	public CompoundTag nbt;
 	public long castStartTime;
+	public long clientTime;
 
 	public SyncAbilityCasting() { /* Nothing to do */ }
 
@@ -29,12 +30,13 @@ public class SyncAbilityCasting implements IMessage<SyncAbilityCasting> {
 //		this.nbt = nbt;
 //	}
 	
-	public SyncAbilityCasting(int playerId, boolean isCasting, int abilitySlot, final CompoundTag nbt, long castStartTime) {
+	public SyncAbilityCasting(int playerId, boolean isCasting, int abilitySlot, final CompoundTag nbt, long castStartTime, long clientTime) {
 		this.playerId = playerId;
 		this.isCasting = isCasting;
 		this.abilitySlot = abilitySlot;
 		this.nbt = nbt;
 		this.castStartTime = castStartTime;
+		this.clientTime = clientTime;
 	}
 
 	@Override
@@ -44,12 +46,13 @@ public class SyncAbilityCasting implements IMessage<SyncAbilityCasting> {
 		buffer.writeInt(message.abilitySlot);
 		buffer.writeNbt(message.nbt);
 		buffer.writeLong(message.castStartTime);
+		buffer.writeLong(message.clientTime);
 	}
 
 	@Override
 	public SyncAbilityCasting decode(final FriendlyByteBuf buffer) {
 		int playerId = buffer.readInt();
-		return new SyncAbilityCasting(playerId, buffer.readBoolean(), buffer.readInt(), buffer.readNbt(), buffer.readLong());
+		return new SyncAbilityCasting(playerId, buffer.readBoolean(), buffer.readInt(), buffer.readNbt(), buffer.readLong(), buffer.readLong());
 	}
 
 	@Override
@@ -68,13 +71,13 @@ public class SyncAbilityCasting implements IMessage<SyncAbilityCasting> {
 					handler.getMagicData().isCasting = message.isCasting;
 
 					if (message.isCasting) {
-						ability.onKeyPressed(sender, () -> {}, message.castStartTime);
+						ability.onKeyPressed(sender, () -> {}, message.castStartTime, message.clientTime);
 					} else {
 						ability.onKeyReleased(sender);
 					}
 				});
 
-				NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> sender), new SyncAbilityCasting(sender.getId(), message.isCasting, message.abilitySlot, message.nbt, message.castStartTime));
+				NetworkHandler.CHANNEL.send(PacketDistributor.TRACKING_ENTITY_AND_SELF.with(() -> sender), new SyncAbilityCasting(sender.getId(), message.isCasting, message.abilitySlot, message.nbt, message.castStartTime, message.clientTime));
 			});
 		}
 


### PR DESCRIPTION
Fixes abilities that spawn entities on ability charge completion (for now, only DragonBallEntity)
- BallLightningAbility
- FireBallAbility

Previously, the server time would desync from the client time if you were in a dimension other than the Overworld, which could cause abilities to fail to complete on the server side.