### PR TITLE
Dynamic animation speed + global dragon movement modifiers + more fixes for large dragons

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/entity/DragonEntity.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/entity/DragonEntity.java
@@ -10,6 +10,7 @@ import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler
 import by.dragonsurvivalteam.dragonsurvival.common.capability.subcapabilities.EmoteCap;
 import by.dragonsurvivalteam.dragonsurvival.common.handlers.DragonSizeHandler;
 import by.dragonsurvivalteam.dragonsurvival.config.ClientConfig;
+import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.magic.common.AbilityAnimation;
 import by.dragonsurvivalteam.dragonsurvival.magic.common.ISecondAnimation;
 import by.dragonsurvivalteam.dragonsurvival.magic.common.active.ActiveDragonAbility;
@@ -67,6 +68,11 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 	AnimationTimer animationTimer = new AnimationTimer();
 	Emote lastEmote;
 	public double seekTime; // Copied from DragonModel.java in order to calculate the correct tickOffset when speed is adjusted for an animation.
+	private final double defaultPlayerWalkSpeed = 0.1;
+	private final double defaultPlayerSneakSpeed = 0.03;
+	private final double defaultPlayerFastSwimSpeed = 0.13;
+	private final double defaultPlayerSwimSpeed = 0.051;
+	private final double defaultPlayerSprintSpeed = 0.165;
 
 	public DragonEntity(EntityType<? extends LivingEntity> type, Level worldIn){
 		super(type, worldIn);
@@ -231,12 +237,20 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 	private <E extends IAnimatable> PlayState predicate(AnimationEvent<E> animationEvent){
 		animationEvent.getAnimationTick();
 		Player player = getPlayer();
-		AnimationController animationController = animationEvent.getController();
+		AnimationController<E> animationController = animationEvent.getController();
 		DragonStateHandler playerStateHandler = DragonUtils.getHandler(player);
 
 		AnimationBuilder builder = new AnimationBuilder();
 
+		boolean useDynamicScaling = false;
 		double animationSpeed = 1;
+		double speedFactor = 1;
+		double baseSpeed = defaultPlayerWalkSpeed;
+		double smallSizeFactor = 0.3;
+		double bigSizeFactor = 1;
+		double baseSize = ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
+		double distanceFromGround = ServerFlightHandler.distanceFromGround(player);
+		double height = DragonSizeHandler.calculateDragonHeight(playerStateHandler.getSize(), ServerConfig.hitboxGrowsPastHuman);
 
 		if(player == null || Stream.of(playerStateHandler.getEmoteData().currentEmotes).anyMatch(s -> s != null && !s.blend && s.animation != null && !s.animation.isBlank())){
 			animationEvent.getController().setAnimation(null);
@@ -254,8 +268,9 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 			renderAbility(builder, curCast);
 		}
 
-		Vec3 motion = new Vec3(player.getX() - player.xo, player.getY() - player.yo, player.getZ() - player.zo);
-		boolean isMovingHorizontal = Math.sqrt(Math.pow(motion.x, 2) + Math.pow(motion.z, 2)) > 0.005;
+		// The reason the threshold is so high here is that lower thresholds cause the player to be stuck transitioning away from the walk animation longer than they should when they stop moving.
+		boolean isMovingHorizontalWalk = player.getDeltaMovement().horizontalDistance() > defaultPlayerWalkSpeed / 5;
+		boolean isMovingHorizontalSneak = player.getDeltaMovement().horizontalDistance() > defaultPlayerSneakSpeed / 5;
 
 		if(playerStateHandler.getMagicData().onMagicSource){
 			neckLocked = false;
@@ -289,7 +304,7 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 					RenderingUtils.addAnimation(builder, "fly_soaring", EDefaultLoopTypes.LOOP, 4, animationController);
 				}
 			}else{
-				if(player.isCrouching() && deltaMovement.y < 0 && ServerFlightHandler.distanceFromGround(player) < 10 && deltaMovement.length() < 4){
+				if(player.isCrouching() && deltaMovement.y < 0 && distanceFromGround < 10 && deltaMovement.length() < 4){
 					neckLocked = false;
 					tailLocked = false;
 					RenderingUtils.addAnimation(builder, "fly_land", EDefaultLoopTypes.LOOP, 2, animationController);
@@ -302,8 +317,6 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 					tailLocked = false;
 					if(deltaMovement.y > 0) {
 						animationSpeed = 2;
-					} else {
-						animationSpeed = 1;
 					}
 					RenderingUtils.addAnimation(builder, "fly", EDefaultLoopTypes.LOOP, 2, animationController);
 				}
@@ -312,10 +325,10 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 			if(ServerFlightHandler.isSpin(player)){
 				neckLocked = false;
 				tailLocked = false;
-				animationSpeed = 1;
 				RenderingUtils.addAnimation(builder, "fly_spin", EDefaultLoopTypes.LOOP, 2, animationController);
 			}else{
-				animationSpeed = 1 + deltaMovement.horizontalDistance() / 10;
+				useDynamicScaling = true;
+				baseSpeed = defaultPlayerFastSwimSpeed; // Default base fast speed for the player
 				RenderingUtils.addAnimation(builder, "swim_fast", EDefaultLoopTypes.LOOP, 2, animationController);
 			}
 		}else if((player.isInLava() || player.isInWaterOrBubble()) && !player.isOnGround()){
@@ -325,7 +338,8 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 				animationSpeed = 2;
 				RenderingUtils.addAnimation(builder, "fly_spin", EDefaultLoopTypes.LOOP, 2, animationController);
 			}else{
-				animationSpeed = 1 + deltaMovement.horizontalDistance() / 10;
+				useDynamicScaling = true;
+				baseSpeed = defaultPlayerSwimSpeed;
 				RenderingUtils.addAnimation(builder, "swim", EDefaultLoopTypes.LOOP, 2, animationController);
 			}
 		}else if(animationController.getCurrentAnimation() != null && (Objects.equals(animationController.getCurrentAnimation().animationName, "fly_land"))) {
@@ -334,11 +348,14 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 			// Don't add any animation
 		}else if(ClientEvents.dragonsJumpingTicks.getOrDefault(this.playerId, 0) > 0){
 			RenderingUtils.addAnimation(builder, "jump", EDefaultLoopTypes.PLAY_ONCE, 2, animationController);
-		}else if(!player.isOnGround() ) {
+		// Extra condition to prevent the player from triggering the fall animation when falling a trivial distance (this happens when you are really big)
+		}else if(!player.isOnGround() && (distanceFromGround > height * 0.15)) {
 			RenderingUtils.addAnimation(builder, "fall_loop", EDefaultLoopTypes.LOOP, 2, animationController);
 		} else if(player.isShiftKeyDown() || !DragonSizeHandler.canPoseFit(player, Pose.STANDING) && DragonSizeHandler.canPoseFit(player, Pose.CROUCHING)){
 			// Player is Sneaking
-			if(isMovingHorizontal && player.animationSpeed != 0f){
+			if(isMovingHorizontalSneak && player.animationSpeed != 0f){
+				useDynamicScaling = true;
+				baseSpeed = defaultPlayerSneakSpeed;
 				RenderingUtils.addAnimation(builder, "sneak_walk", EDefaultLoopTypes.LOOP, 5, animationController);
 			}else if(playerStateHandler.getMovementData().dig){
 				RenderingUtils.addAnimation(builder, "dig_sneak", EDefaultLoopTypes.LOOP, 5, animationController);
@@ -346,10 +363,11 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 				RenderingUtils.addAnimation(builder, "sneak", EDefaultLoopTypes.LOOP, 5, animationController);
 			}
 		}else if(player.isSprinting()){
-			RenderingUtils.setAnimationSpeed(1 + deltaMovement.horizontalDistance() / 10, seekTime, animationController);
+			useDynamicScaling = true;
+			baseSpeed = defaultPlayerSprintSpeed;
 			RenderingUtils.addAnimation(builder, "run", EDefaultLoopTypes.LOOP, 2, animationController);
-		}else if(isMovingHorizontal && player.animationSpeed != 0f){
-			RenderingUtils.setAnimationSpeed(1 + deltaMovement.horizontalDistance() / 10, seekTime, animationController);
+		}else if(isMovingHorizontalWalk && player.animationSpeed != 0f){
+			useDynamicScaling = true;
 			RenderingUtils.addAnimation(builder, "walk", EDefaultLoopTypes.LOOP, 2, animationController);
 		}else if(playerStateHandler.getMovementData().dig){
 			RenderingUtils.addAnimation(builder, "dig", EDefaultLoopTypes.LOOP, 2, animationController);
@@ -362,9 +380,16 @@ public class DragonEntity extends LivingEntity implements IAnimatable, CommonTra
 		}
 
 		animationController.setAnimation(builder);
-		if(animationController.getAnimationState() != AnimationState.Transitioning) {
-			RenderingUtils.setAnimationSpeed(animationSpeed, animationEvent.getAnimationTick(), animationController);
+		double finalAnimationSpeed = animationSpeed;
+		if(useDynamicScaling) {
+			double horizontalDistance = deltaMovement.horizontalDistance();
+			double speedComponent = (horizontalDistance - baseSpeed) / baseSpeed * speedFactor;
+			double sizeDistance = playerStateHandler.getSize() - baseSize;
+			double sizeFactor = sizeDistance >= 0 ? bigSizeFactor : smallSizeFactor;
+			double sizeComponent = baseSize / (baseSize + sizeDistance * sizeFactor);
+ 			finalAnimationSpeed = (animationSpeed + speedComponent) * sizeComponent;
 		}
+		RenderingUtils.setAnimationSpeed(finalAnimationSpeed, animationEvent.getAnimationTick(), animationController);
 
 		return PlayState.CONTINUE;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonBonusHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonBonusHandler.java
@@ -7,14 +7,17 @@ import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.magic.DragonAbilities;
 import by.dragonsurvivalteam.dragonsurvival.magic.abilities.ForestDragon.passive.CliffhangerAbility;
 import by.dragonsurvivalteam.dragonsurvival.registry.DragonEffects;
+import by.dragonsurvivalteam.dragonsurvival.registry.DragonModifiers;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import by.dragonsurvivalteam.dragonsurvival.util.ResourceHelper;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.IndirectEntityDamageSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.projectile.Snowball;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.event.PlayLevelSoundEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
@@ -90,7 +93,13 @@ public class DragonBonusHandler{
 					CliffhangerAbility ability = DragonAbilities.getSelfAbility(living, CliffhangerAbility.class);
 					distance -= ability.getHeight();
 				}
-				distance -= dragonStateHandler.getLevel().jumpHeight;
+
+				float gravity = (float) livingFallEvent.getEntity().getAttributeValue(ForgeMod.ENTITY_GRAVITY.get());
+				// TODO: Added a fudge factor of 1.5 here. Not sure why it is needed but otherwise you begin to hurt yourself at very high jump heights even though the calculation here is identical to the push force calculation.
+				float jumpHeight = (float) DragonModifiers.getJumpBonus(dragonStateHandler) * 1.5f;
+
+				// Calculating the peak of the jump
+				distance -= (float) (Math.pow(jumpHeight, 2.0) / (2 * gravity));
 
 				AbstractDragonBody body = dragonStateHandler.getBody();
 				if (body != null && body.getGravityMult() <= 1.0) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/EventHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/EventHandler.java
@@ -11,6 +11,7 @@ import by.dragonsurvivalteam.dragonsurvival.network.status.PlayerJumpSync;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSBlocks;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSItems;
 import by.dragonsurvivalteam.dragonsurvival.registry.DragonEffects;
+import by.dragonsurvivalteam.dragonsurvival.registry.DragonModifiers;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import by.dragonsurvivalteam.dragonsurvival.util.ResourceHelper;
 import net.minecraft.core.BlockPos;
@@ -381,16 +382,11 @@ public class EventHandler{
 			if(dragonStateHandler.isDragon()){
 				Double jumpBonus = 0.0;
 				if (dragonStateHandler.getBody() != null) {
-					jumpBonus = dragonStateHandler.getBody().getJumpBonus();
-					if (ServerConfig.allowLargeScaling) {
-						jumpBonus += ServerConfig.largeJumpHeightScalar * (dragonStateHandler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
-					}
+					jumpBonus = DragonModifiers.getJumpBonus(dragonStateHandler);
 				}
-				switch(dragonStateHandler.getLevel()){
-					case NEWBORN -> living.push(0, ServerConfig.newbornJump + jumpBonus, 0); //1+ block
-					case YOUNG -> living.push(0, ServerConfig.youngJump + jumpBonus, 0); //1.5+ block
-					case ADULT -> living.push(0, ServerConfig.adultJump + jumpBonus, 0); //2+ blocks
-				}
+
+				living.push(0, jumpBonus, 0);
+
 				if(living instanceof ServerPlayer){
 					if(living.getServer().isSingleplayer()){
 						NetworkHandler.CHANNEL.send(PacketDistributor.ALL.noArg(), new PlayerJumpSync(living.getId(), 20)); // 42

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/magic/MagicHandler.java
@@ -73,21 +73,13 @@ public class MagicHandler{
 		AttributeInstance moveSpeed = player.getAttribute(Attributes.MOVEMENT_SPEED);
 
 		DragonStateProvider.getCap(player).ifPresent(cap -> {
-			if(!cap.isDragon() || cap.getLevel() != DragonLevel.ADULT){
-				if(moveSpeed.getModifier(DRAGON_PASSIVE_MOVEMENT_SPEED) != null){
-					moveSpeed.removeModifier(DRAGON_PASSIVE_MOVEMENT_SPEED);
-				}
+
+			// TODO: Remove this code after a while once the patch has been in for a bit. For now this is here to prevent any issues with save files that have the old data.
+			if(moveSpeed.getModifier(DRAGON_PASSIVE_MOVEMENT_SPEED) != null){
+				moveSpeed.removeModifier(DRAGON_PASSIVE_MOVEMENT_SPEED);
 			}
+
 			if(cap.isDragon()) {
-				if(cap.getLevel() == DragonLevel.ADULT){
-					AttributeModifier move_speed = new AttributeModifier(DRAGON_PASSIVE_MOVEMENT_SPEED, "DRAGON_MOVE_SPEED", 0.2F, AttributeModifier.Operation.MULTIPLY_TOTAL);
-	
-					if(moveSpeed.getModifier(DRAGON_PASSIVE_MOVEMENT_SPEED) == null){
-						moveSpeed.addTransientModifier(move_speed);
-					}
-				}
-	
-	
 				if(cap.getMagicData().abilities.isEmpty() || cap.getMagicData().innateDragonAbilities.isEmpty() || cap.getMagicData().activeDragonAbilities.isEmpty()){
 					cap.getMagicData().initAbilities(cap.getType());
 				}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/config/ServerConfig.java
@@ -87,6 +87,9 @@ public class ServerConfig{
 	@ConfigRange( min = 1, max = 1000 )
 	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "big_dragon"}, key = "largeMaxHealth", comment = "The maximum health when the dragon is at maximum growth size if large scaling is enabled.")
 	public static Integer largeMaxHealth = 80;
+	@ConfigRange( min = 0.0, max = 100.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "big_dragon"}, key = "largeMovementSpeedScalar", comment = "The bonus movement speed multiplier per 60 size when the dragon is at maximum growth size if large scaling is enabled.")
+	public static Double largeMovementSpeedScalar = 0.0;
 
 	@ConfigRange( min = 0.0, max = 100.0 )
 	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "big_dragon"}, key = "largeDamageBonus", comment = "The bonus damage when the dragon is at maximum growth size if large scaling is enabled.")
@@ -132,6 +135,18 @@ public class ServerConfig{
 	@ConfigRange( min = 14.0, max = 1000000.0 )
 	@ConfigOption( side = ConfigSide.SERVER, category = {"growth"}, key = "maxGrowthSize", comment = "Defines the max size your dragon can grow to. Values that are too high can break your game. It is not advisable to set a number higher than 60." )
 	public static Double maxGrowthSize = DEFAULT_MAX_GROWTH_SIZE;
+
+	@ConfigRange( min = 0, max = 1000000.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "standard_dragon"}, key = "moveSpeedNewborn", comment = "The movement speed multiplier for newborn dragons. Default is 1.0.")
+	public static Double moveSpeedNewborn = 1.0;
+
+	@ConfigRange( min = 0, max = 1000000.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "standard_dragon"}, key = "moveSpeedYoung", comment = "The movement speed multiplier for young dragons. Default is 1.0.")
+	public static Double moveSpeedYoung = 1.0;
+
+	@ConfigRange( min = 0, max = 1000000.0 )
+	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "standard_dragon"}, key = "moveSpeedAdult", comment = "The movement speed multiplier for adult dragons. Default is 1.0.")
+	public static Double moveSpeedAdult = 1.0;
 
 	@ConfigRange( min = 0, max = 1000000.0 )
 	@ConfigOption( side = ConfigSide.SERVER, category = {"growth", "standard_dragon"}, key = "reachBonus", comment = "The bonus that is given to dragons at 60 size. The bonus gradually scales up to the maximum size. Human players have 1.0x reach and a size 60 dragon will have 1.5x distance with default values.")

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/DragonModifiers.java
@@ -9,15 +9,12 @@ import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.ForgeMod;
-import net.minecraftforge.event.entity.living.LivingEvent.LivingTickEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
 import javax.annotation.Nullable;
@@ -26,12 +23,13 @@ import java.util.UUID;
 
 @EventBusSubscriber
 public class DragonModifiers{
-	public static final UUID REACH_MODIFIER_UUID = UUID.fromString("7455d5c7-4e1f-4cca-ab46-d79353764020");
-	public static final UUID HEALTH_MODIFIER_UUID = UUID.fromString("03574e62-f9e4-4f1b-85ad-fde00915e446");
-	public static final UUID DAMAGE_MODIFIER_UUID = UUID.fromString("5bd3cebc-132e-4f9d-88ef-b686c7ad1e2c");
-	public static final UUID SWIM_SPEED_MODIFIER_UUID = UUID.fromString("2a9341f3-d19e-446c-924b-7cf2e5259e10");
-	public static final UUID ATTACK_RANGE_MODIFIER_UUID = UUID.fromString("a2e9a028-4bef-48d4-a25b-9cfdcac99480");
-	public static final UUID STEP_HEIGHT_MODIFIER_UUID = UUID.fromString("f3b0b3e3-3b7d-4b1b-8f3d-3b7d4b1b8f3d");
+	private static final UUID DRAGON_REACH_MODIFIER = UUID.fromString("7455d5c7-4e1f-4cca-ab46-d79353764020");
+	private static final UUID DRAGON_HEALTH_MODIFIER = UUID.fromString("03574e62-f9e4-4f1b-85ad-fde00915e446");
+	private static final UUID DRAGON_DAMAGE_MODIFIER = UUID.fromString("5bd3cebc-132e-4f9d-88ef-b686c7ad1e2c");
+	private static final UUID DRAGON_SWIM_SPEED_MODIFIER = UUID.fromString("2a9341f3-d19e-446c-924b-7cf2e5259e10");
+	private static final UUID DRAGON_ATTACK_RANGE_MODIFIER = UUID.fromString("a2e9a028-4bef-48d4-a25b-9cfdcac99480");
+	private static final UUID DRAGON_STEP_HEIGHT_MODIFIER = UUID.fromString("f3b0b3e3-3b7d-4b1b-8f3d-3b7d4b1b8f3d");
+	private static final UUID DRAGON_MOVEMENT_SPEED_MODIFIER = UUID.fromString("a11bba07-27e2-4c98-ac2c-34ae9f9b0694");
 
 	private static final UUID DRAGON_BODY_MOVEMENT_SPEED = UUID.fromString("114fe18b-60fd-4284-b6ce-14d090454402");
 	private static final UUID DRAGON_BODY_ARMOR = UUID.fromString("8728438d-c838-4968-9382-efb95a36d72a");
@@ -53,7 +51,7 @@ public class DragonModifiers{
 			double healthModifierPercentage = Math.min(1.0, (size - DragonLevel.NEWBORN.size) / (ServerConfig.maxHealthSize - DragonLevel.NEWBORN.size));
 			healthModifier = Mth.lerp(healthModifierPercentage, ServerConfig.minHealth, ServerConfig.maxHealth) - 20;
 		}
-		return new AttributeModifier(HEALTH_MODIFIER_UUID, "Dragon Health Adjustment", healthModifier, AttributeModifier.Operation.ADDITION);
+		return new AttributeModifier(DRAGON_HEALTH_MODIFIER, "Dragon Health Adjustment", healthModifier, AttributeModifier.Operation.ADDITION);
 	}
 
 	public static AttributeModifier buildReachMod(double size){
@@ -64,7 +62,7 @@ public class DragonModifiers{
 		else {
 			reachModifier = Math.max(ServerConfig.reachBonus, (size - DragonLevel.NEWBORN.size) / (ServerConfig.DEFAULT_MAX_GROWTH_SIZE - DragonLevel.NEWBORN.size) * ServerConfig.reachBonus);
 		}
-		return new AttributeModifier(REACH_MODIFIER_UUID, "Dragon Reach Adjustment", reachModifier, Operation.MULTIPLY_BASE);
+		return new AttributeModifier(DRAGON_REACH_MODIFIER, "Dragon Reach Adjustment", reachModifier, Operation.MULTIPLY_BASE);
 	}
 	
 	public static AttributeModifier buildAttackRangeMod(double size) {
@@ -75,7 +73,7 @@ public class DragonModifiers{
 		else {
 			rangeMod = Math.max(ServerConfig.attackRangeBonus, (size - DragonLevel.NEWBORN.size) / (ServerConfig.DEFAULT_MAX_GROWTH_SIZE - DragonLevel.NEWBORN.size) * ServerConfig.attackRangeBonus);
 		}
-		return new AttributeModifier(ATTACK_RANGE_MODIFIER_UUID, "Dragon Attack Range Adjustment", rangeMod, Operation.MULTIPLY_BASE);
+		return new AttributeModifier(DRAGON_ATTACK_RANGE_MODIFIER, "Dragon Attack Range Adjustment", rangeMod, Operation.MULTIPLY_BASE);
 	}
 
 	public static AttributeModifier buildDamageMod(DragonStateHandler handler, boolean isDragon){
@@ -84,11 +82,11 @@ public class DragonModifiers{
 			double damageModPercentage = Math.min(1.0, (handler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / (ServerConfig.maxGrowthSize - ServerConfig.DEFAULT_MAX_GROWTH_SIZE));
 			ageBonus = Mth.lerp(damageModPercentage, ageBonus, ServerConfig.largeDamageBonus);
 		}
-		return new AttributeModifier(DAMAGE_MODIFIER_UUID, "Dragon Damage Adjustment", ageBonus, Operation.ADDITION);
+		return new AttributeModifier(DRAGON_DAMAGE_MODIFIER, "Dragon Damage Adjustment", ageBonus, Operation.ADDITION);
 	}
 
 	public static AttributeModifier buildSwimSpeedMod(AbstractDragonType dragonType){
-		return new AttributeModifier(SWIM_SPEED_MODIFIER_UUID, "Dragon Swim Speed Adjustment", Objects.equals(dragonType, DragonTypes.SEA) && ServerConfig.seaSwimmingBonuses ? 1 : 0, Operation.ADDITION);
+		return new AttributeModifier(DRAGON_SWIM_SPEED_MODIFIER, "Dragon Swim Speed Adjustment", Objects.equals(dragonType, DragonTypes.SEA) && ServerConfig.seaSwimmingBonuses ? 1 : 0, Operation.ADDITION);
 	}
 
 	public static AttributeModifier buildStepHeightMod(DragonStateHandler handler, double size) {
@@ -96,7 +94,25 @@ public class DragonModifiers{
 		if(size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE && ServerConfig.allowLargeScaling)  {
 			stepHeightBonus += ServerConfig.largeStepHeightScalar * (size - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
 		}
-		return new AttributeModifier(STEP_HEIGHT_MODIFIER_UUID, "Dragon Step Height Adjustment", stepHeightBonus, Operation.ADDITION);
+		return new AttributeModifier(DRAGON_STEP_HEIGHT_MODIFIER, "Dragon Step Height Adjustment", stepHeightBonus, Operation.ADDITION);
+	}
+
+	public static AttributeModifier buildMovementSpeedMod(DragonStateHandler handler, double size) {
+		double moveSpeedMultiplier = 1;
+		if(handler.getLevel() == DragonLevel.NEWBORN) {
+			double youngPercent = Math.min(1.0, (size - DragonLevel.NEWBORN.size) / (DragonLevel.YOUNG.size - DragonLevel.NEWBORN.size));
+			moveSpeedMultiplier = Mth.lerp(youngPercent, ServerConfig.moveSpeedNewborn, ServerConfig.moveSpeedYoung);
+		} else if(handler.getLevel() == DragonLevel.YOUNG) {
+			double adultPercent = Math.min(1.0, (size - DragonLevel.YOUNG.size) / (DragonLevel.ADULT.size - DragonLevel.YOUNG.size));
+			moveSpeedMultiplier = Mth.lerp(adultPercent, ServerConfig.moveSpeedYoung, ServerConfig.moveSpeedAdult);
+		} else if(handler.getLevel() == DragonLevel.ADULT) {
+			if(ServerConfig.allowLargeScaling && size > ServerConfig.DEFAULT_MAX_GROWTH_SIZE) {
+				moveSpeedMultiplier = ServerConfig.moveSpeedAdult + ServerConfig.largeMovementSpeedScalar * (size - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
+			} else {
+				moveSpeedMultiplier = ServerConfig.moveSpeedAdult;
+			}
+		}
+		return new AttributeModifier(DRAGON_MOVEMENT_SPEED_MODIFIER, "Dragon Movement Speed Adjustment", moveSpeedMultiplier - 1, AttributeModifier.Operation.MULTIPLY_TOTAL);
 	}
 
 	public static void updateModifiers(final Player player) {
@@ -124,6 +140,9 @@ public class DragonModifiers{
 
 				AttributeModifier stepHeight = buildStepHeightMod(handler, size);
 				updateStepHeightModifier(player, stepHeight);
+
+				AttributeModifier moveSpeed = buildMovementSpeedMod(handler, size);
+				updateMovementSpeedModifier(player, moveSpeed);
 			} else {
 				// Remove the dragon attribute modifiers
 				AttributeModifier oldMod = getHealthModifier(player);
@@ -162,6 +181,12 @@ public class DragonModifiers{
 				oldMod = getStepHeightModifier(player);
 				if (oldMod != null) {
 					AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get()));
+					max.removeModifier(oldMod);
+				}
+
+				oldMod = getMovementSpeedModifier(player);
+				if (oldMod != null) {
+					AttributeInstance max = Objects.requireNonNull(player.getAttribute(Attributes.MOVEMENT_SPEED));
 					max.removeModifier(oldMod);
 				}
 			}
@@ -240,32 +265,37 @@ public class DragonModifiers{
 
 	@Nullable
 	public static AttributeModifier getReachModifier(Player player){
-		return Objects.requireNonNull(player.getAttribute(ForgeMod.REACH_DISTANCE.get())).getModifier(REACH_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.REACH_DISTANCE.get())).getModifier(DRAGON_REACH_MODIFIER);
 	}
 
 	@Nullable
 	public static AttributeModifier getHealthModifier(Player player){
-		return Objects.requireNonNull(player.getAttribute(Attributes.MAX_HEALTH)).getModifier(HEALTH_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(Attributes.MAX_HEALTH)).getModifier(DRAGON_HEALTH_MODIFIER);
 	}
 
 	@Nullable
 	public static AttributeModifier getDamageModifier(Player player){
-		return Objects.requireNonNull(player.getAttribute(Attributes.ATTACK_DAMAGE)).getModifier(DAMAGE_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(Attributes.ATTACK_DAMAGE)).getModifier(DRAGON_DAMAGE_MODIFIER);
 	}
 
 	@Nullable
 	public static AttributeModifier getSwimSpeedModifier(Player player){
-		return Objects.requireNonNull(player.getAttribute(ForgeMod.SWIM_SPEED.get())).getModifier(SWIM_SPEED_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.SWIM_SPEED.get())).getModifier(DRAGON_SWIM_SPEED_MODIFIER);
 	}
 	
 	@Nullable
 	public static AttributeModifier getAttackRangeModifier(Player player) {
-		return Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get())).getModifier(ATTACK_RANGE_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.ATTACK_RANGE.get())).getModifier(DRAGON_ATTACK_RANGE_MODIFIER);
 	}
 
 	@Nullable
 	public static AttributeModifier getStepHeightModifier(Player player) {
-		return Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get())).getModifier(STEP_HEIGHT_MODIFIER_UUID);
+		return Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get())).getModifier(DRAGON_STEP_HEIGHT_MODIFIER);
+	}
+
+	@Nullable
+	public static AttributeModifier getMovementSpeedModifier(Player player) {
+		return Objects.requireNonNull(player.getAttribute(Attributes.MOVEMENT_SPEED)).getModifier(DRAGON_MOVEMENT_SPEED_MODIFIER);
 	}
 
 	public static void updateReachModifier(Player player, AttributeModifier mod){
@@ -323,5 +353,31 @@ public class DragonModifiers{
 		AttributeInstance max = Objects.requireNonNull(player.getAttribute(ForgeMod.STEP_HEIGHT_ADDITION.get()));
 		max.removeModifier(mod);
 		max.addPermanentModifier(mod);
+	}
+
+	public static void updateMovementSpeedModifier(Player player, AttributeModifier mod) {
+		if(!ServerConfig.bonuses) {
+			return;
+		}
+		AttributeInstance max = Objects.requireNonNull(player.getAttribute(Attributes.MOVEMENT_SPEED));
+		max.removeModifier(mod);
+		max.addPermanentModifier(mod);
+	}
+
+	public static double getJumpBonus(DragonStateHandler handler) {
+		double jumpBonus = handler.getBody().getJumpBonus();
+		if (handler.getBody() != null) {
+			jumpBonus = handler.getBody().getJumpBonus();
+			if (ServerConfig.allowLargeScaling) {
+				jumpBonus += ServerConfig.largeJumpHeightScalar * (handler.getSize() - ServerConfig.DEFAULT_MAX_GROWTH_SIZE) / ServerConfig.DEFAULT_MAX_GROWTH_SIZE;
+			}
+		}
+		switch(handler.getLevel()){
+			case NEWBORN -> jumpBonus += ServerConfig.newbornJump; //1+ block
+			case YOUNG -> jumpBonus += ServerConfig.youngJump; //1.5+ block
+			case ADULT -> jumpBonus += ServerConfig.adultJump; //2+ blocks
+		}
+
+		return jumpBonus;
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/DragonDestructionHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/DragonDestructionHandler.java
@@ -197,7 +197,7 @@ public class DragonDestructionHandler {
                     boundingBox = player.getBoundingBox();
                 }
 
-                boundingBox = boundingBox.inflate(1.25);
+                boundingBox = boundingBox.inflate(1.5 + (dragonStateHandler.getSize() / ServerConfig.DEFAULT_MAX_GROWTH_SIZE) * 0.15);
 
                 checkAndDestroyCollidingBlocks(dragonStateHandler, event, boundingBox);
                 checkAndDamageCrushedEntities(dragonStateHandler, player, boundingBox);


### PR DESCRIPTION
-Increased the size of the dragon destruction hitbox to prevent getting stuck on blocks 
-Added dynamic animation speed based on size and movement for certain animations 
-Added global dragon speed bonus that is configurable in the config file (default to 1.0) 
-Removed code that was modifying movement speed incorrectly from MagicHandler.java
-Added a fix to reduce fall damage based on your jump height bonus
-Falling a short distance when you are excessively large doesn't trigger the falling animation (so that you smoothly walk over slightly uneven terrain if you are giant)