### PR TITLE
Add startDestroyBlock as another tool swapping injection

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/tool_swap/MixinMultiPlayerGameModeEnd.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/tool_swap/MixinMultiPlayerGameModeEnd.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = MultiPlayerGameMode.class, priority = 10_000)
 public class MixinMultiPlayerGameModeEnd {
-    @Inject(method = "continueDestroyBlock", at = @At("RETURN"))
+    @Inject(method = { "startDestroyBlock", "continueDestroyBlock" }, at = @At("RETURN"))
     private void finishSwap(final BlockPos blockPosition, final Direction directionFacing, final CallbackInfoReturnable<Boolean> callback) {
         ToolUtils.swapFinish(Minecraft.getInstance().player);
     }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/tool_swap/MixinMultiPlayerGameModeStart.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/tool_swap/MixinMultiPlayerGameModeStart.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = MultiPlayerGameMode.class, priority = 1)
 public class MixinMultiPlayerGameModeStart {
-    @Inject(method = "continueDestroyBlock", at = @At("HEAD"))
+    @Inject(method = { "startDestroyBlock", "continueDestroyBlock" }, at = @At("HEAD"))
     private void startSwap(final BlockPos blockPosition, final Direction directionFacing, final CallbackInfoReturnable<Boolean> callback) {
         LocalPlayer localPlayer = Minecraft.getInstance().player;
 


### PR DESCRIPTION
Fixes #388

Previously, `startDestroyBlock` and `continueDestroyBlock` would trigger a block attack with two different items (an empty hand first, and the claw tool afterwards). My understanding is that this would cause `attack()` to fire twice on the target block, leading to bugs including Storage Drawers dropping two items. This makes both methods use the same held item.