### PR TITLE
fix mowzie's mob incompatibility

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRender.java
@@ -33,7 +33,6 @@ import by.dragonsurvivalteam.dragonsurvival.server.handlers.ServerFlightHandler;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import by.dragonsurvivalteam.dragonsurvival.util.Functions;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
@@ -44,14 +43,12 @@ import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.LivingEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.ParrotOnShoulderLayer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeableArmorItem;
 import net.minecraft.world.item.ItemStack;
@@ -64,7 +61,6 @@ import net.minecraftforge.event.TickEvent.RenderTickEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import software.bernie.geckolib.core.object.Color;
 
@@ -260,7 +256,7 @@ public class ClientDragonRender{
 					RenderNameTagEvent renderNameplateEvent = new RenderNameTagEvent(player, player.getDisplayName(), playerRenderer, poseStack, renderTypeBuffer, eventLight, partialRenderTick);
 					MinecraftForge.EVENT_BUS.post(renderNameplateEvent);
 
-					if (renderNameplateEvent.getResult() != Event.Result.DENY && (renderNameplateEvent.getResult() == Event.Result.ALLOW || ((AccessorLivingRenderer) playerRenderer).callShouldShowName(player))) {
+					if (renderNameplateEvent.getResult() != Event.Result.DENY && (renderNameplateEvent.getResult() == Event.Result.ALLOW || ((AccessorLivingRenderer) playerRenderer).dragonsurvival$callShouldShowName(player))) {
 						((AccessorEntityRenderer) playerRenderer).callRenderNameTag(player, renderNameplateEvent.getContent(), poseStack, renderTypeBuffer, eventLight);
 					}
 				}
@@ -385,7 +381,7 @@ public class ClientDragonRender{
 
 				if (!player.isSpectator()) {
 					// Render the parrot on the players shoulder
-					((AccessorLivingRenderer) playerRenderer).getRenderLayers().stream().filter(ParrotOnShoulderLayer.class::isInstance).findAny().ifPresent(renderLayer -> {
+					((AccessorLivingRenderer) playerRenderer).dragonsurvival$getRenderLayers().stream().filter(ParrotOnShoulderLayer.class::isInstance).findAny().ifPresent(renderLayer -> {
 						poseStack.scale(1.0F / scale, 1.0F / scale, 1.0F / scale);
 						poseStack.mulPose(Axis.XN.rotationDegrees(180.0F));
 						double height = 1.3 * scale;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/AccessorLivingRenderer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/AccessorLivingRenderer.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Mixin( LivingEntityRenderer.class )
 public interface AccessorLivingRenderer{
 	@Accessor( "layers" )
-	List<RenderLayer> getRenderLayers();
+	List<RenderLayer> dragonsurvival$getRenderLayers();
 	@Invoker( "shouldShowName" )
-	boolean callShouldShowName(LivingEntity p_177070_1_);
+	boolean dragonsurvival$callShouldShowName(LivingEntity p_177070_1_);
 }


### PR DESCRIPTION
the accessor was previously overriding a `getRenderLayers` method from geckolibs `GeoRenderer` interface
(when https://github.com/BobMowzie/MowziesMobs/blob/master/src/main/java/com/bobmowzie/mowziesmobs/client/render/entity/player/GeckoRenderPlayer.java was being used)

fixes #560 