### PR TITLE
Refactor toggleWings

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -534,17 +534,18 @@ public class ClientFlightHandler {
             return;
         }
 
-        //Allows toggling the wings if food level is above 0, player is creative, wings are already enabled (allows disabling even when hungry) or if config options is turned on
-        if(!isTrapped(player) && (hasEnoughFoodToStartFlight(player) || player.isCreative() || handler.isWingsSpread())){
-            PacketDistributor.sendToServer(new SyncFlyingStatus.Data(player.getId(), !handler.isWingsSpread()));
-            return;
-        }
+		if (isTrapped(player)) return;
 
-        if(!isTrapped(player))
-        {
-            player.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
-        }
-    }
+		//Allows toggling the wings if food level is above 0, player is creative, wings are already enabled (allows disabling even when hungry) or if config options is turned on
+		// NOTE: Folding wings is currently disallowed when trapped; but the Trapped status effect already folds wings
+		boolean isWingsSpread = handler.isWingsSpread();
+		if (isWingsSpread || player.isCreative() || hasEnoughFoodToStartFlight(player)) {
+			PacketDistributor.sendToServer(new SyncFlyingStatus.Data(player.getId(), !isWingsSpread));
+			return;
+		}
+
+		player.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
+	}
 
     private static void tryJumpToFly(LocalPlayer player, DragonStateHandler handler) {
         if (player.isCreative() || player.isSpectator()) return;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -480,6 +480,9 @@ public class ClientFlightHandler {
 		}
 	}
 
+	// FIXME: spin and toggleWings are duplicates for handling mouse and keyboard inputs
+	// Handling should be done by checking KeyMappings while listening to ClientTickEvent.Post via #consumeClick()
+	// Spin is currently checked for both times, but toggleWings only for the keyboard
 	@SubscribeEvent
 	public static void spin(InputEvent.MouseButton.Pre keyInputEvent) {
 		Minecraft minecraft = Minecraft.getInstance();

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -553,6 +553,8 @@ public class ClientFlightHandler {
         if (!handler.hasFlight()) return;
         if (handler.isWingsSpread()) return;
 
+		if (isTrapped(player)) return;
+
         Vec3 lookVec = player.getLookAngle();
         if (lookAtSkyForFlight && lookVec.y <= 0.8) return;
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -93,7 +93,6 @@ public class ClientFlightHandler {
 		if (localPlayer == null) return;
 		localPlayer.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
 	});
-	private static long lastHungerMessage;
 	private static int levitationLeft;
 
 	@SubscribeEvent

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -558,13 +558,14 @@ public class ClientFlightHandler {
 
         if (player.onGround() || player.isInLava() || player.isInWater()) return;
 
-        if (hasEnoughFoodToStartFlight(player) || player.isCreative()) {
+        if (hasEnoughFoodToStartFlight(player)) { // Creative players are already disallowed from using jump-to-fly
             PacketDistributor.sendToServer(new SyncFlyingStatus.Data(player.getId(), true));
-        } else {
-            if (lastHungerMessage == 0 || lastHungerMessage + TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS) < System.currentTimeMillis()) {
-                lastHungerMessage = System.currentTimeMillis();
-                player.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
-            }
+			return;
+        }
+
+        if (lastHungerMessage == 0 || lastHungerMessage + TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS) < System.currentTimeMillis()) {
+            lastHungerMessage = System.currentTimeMillis();
+            player.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
         }
     }
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -11,6 +11,7 @@ import by.dragonsurvivalteam.dragonsurvival.network.flight.SyncFlyingStatus;
 import by.dragonsurvivalteam.dragonsurvival.network.flight.SyncSpinStatus;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSEffects;
 import by.dragonsurvivalteam.dragonsurvival.server.handlers.ServerFlightHandler;
+import by.dragonsurvivalteam.dragonsurvival.util.ActionWithCooldown;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import by.dragonsurvivalteam.dragonsurvival.util.Functions;
 import com.mojang.blaze3d.platform.Window;
@@ -87,6 +88,11 @@ public class ClientFlightHandler {
 	static float lastIncrease;
 	static float lastZoom = 1f;
 
+	private static final ActionWithCooldown hungerMessageWithCooldown = new ActionWithCooldown(30_000, () -> {
+		var localPlayer = Minecraft.getInstance().player;
+		if (localPlayer == null) return;
+		localPlayer.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
+	});
 	private static long lastHungerMessage;
 	private static int levitationLeft;
 
@@ -570,10 +576,7 @@ public class ClientFlightHandler {
 			return;
 		}
 
-		if (lastHungerMessage == 0 || lastHungerMessage + TimeUnit.MILLISECONDS.convert(30, TimeUnit.SECONDS) < System.currentTimeMillis()) {
-			lastHungerMessage = System.currentTimeMillis();
-			player.sendSystemMessage(Component.translatable("ds.wings.nohunger"));
-		}
+		hungerMessageWithCooldown.tryRun();
 	}
 
 	private static boolean isTrapped(LivingEntity entity) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/ActionWithCooldown.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/ActionWithCooldown.java
@@ -1,0 +1,38 @@
+package by.dragonsurvivalteam.dragonsurvival.util;
+
+public class ActionWithCooldown {
+
+    private final long cooldownMs;
+    private final Runnable action;
+
+    private long nextAllowedRunMs = 0;
+
+    public ActionWithCooldown(long cooldownMs, Runnable action) {
+        this.cooldownMs = cooldownMs;
+        this.action = action;
+    }
+
+    public long getCooldownMs() {
+        return cooldownMs;
+    }
+
+    public Runnable getAction() {
+        return action;
+    }
+
+    public boolean tryRun() {
+        if (System.currentTimeMillis() < nextAllowedRunMs) return false;
+
+        forceRun();
+        return true;
+    }
+
+    public void forceRun() {
+        action.run();
+        nextAllowedRunMs = System.currentTimeMillis() + cooldownMs;
+    }
+
+    public void resetCooldown() {
+        nextAllowedRunMs = 0;
+    }
+}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/ActionWithCooldown.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/ActionWithCooldown.java
@@ -1,10 +1,19 @@
 package by.dragonsurvivalteam.dragonsurvival.util;
 
+/**
+ * Handles running an action with a set cooldown.
+ * <br/>
+ * {@link #tryRun()} can be invoked repeatedly, and it won't invoke
+ * the action until the cooldown has passed.
+ */
 public class ActionWithCooldown {
 
     private final long cooldownMs;
     private final Runnable action;
 
+    /**
+     * The time at which the action can be run again
+     */
     private long nextAllowedRunMs = 0;
 
     public ActionWithCooldown(long cooldownMs, Runnable action) {
@@ -20,6 +29,11 @@ public class ActionWithCooldown {
         return action;
     }
 
+    /**
+     * Runs the action if the cooldown has passed. Starts the cooldown again upon success.
+     *
+     * @return True if the action was run, false if the cooldown hasn't passed yet.
+     */
     public boolean tryRun() {
         if (System.currentTimeMillis() < nextAllowedRunMs) return false;
 
@@ -27,11 +41,17 @@ public class ActionWithCooldown {
         return true;
     }
 
+    /**
+     * Runs the action regardless of the cooldown. Starts the cooldown again.
+     */
     public void forceRun() {
         action.run();
         nextAllowedRunMs = System.currentTimeMillis() + cooldownMs;
     }
 
+    /**
+     * Resets the next allowed run time to 0, allowing the action to be run immediately next time.
+     */
     public void resetCooldown() {
         nextAllowedRunMs = 0;
     }


### PR DESCRIPTION
Refactors `toggleWings()` and some related spin action code.

Mainly reduces nesting via early returns, extracts methods for clarity, and overall cleans up the code section without any significant semantic changes.

I added `ActionWithCooldown` as a separate class to handle sending a chat message with a cooldown to separate class responsibility, something that was originally handled by `ClientFlightHandler` itself. The helper class can be improved or split up further later. (Or, if a similar one already exists somewhere, it would probably be better to use it instead.)

Also fixes a bug where the Trapped effect could be bypassed by rapidly mashing Jump while in the air, as the code did not check for the trapped condition.

Currently, `toggleWings()` and `spin()` listen for keyboard and mouse events respectively and are effectively duplicates. Input handling should be listened for through `ClientTickEvent.Post` via `KeyMappings#consumeClick()` (according to NeoForge docs). I annotated the code with a FIXME, and it should be refactored later. At a quick glance, `KeyInputHandler` also uses `InputEvent` for handling keybinds, something that NeoForge warns about, so all keybind handling should probably be reworked.