### PR TITLE
Fix crash when Tabbing over UI elements

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -436,7 +436,7 @@ public class DragonEditorScreen extends Screen {
 		defaultSkinCheckbox.setTooltip(Tooltip.create(Component.translatable("ds.gui.dragon_editor.default_skin.tooltip")));
 		addRenderableWidget(defaultSkinCheckbox);
 
-		ExtendedButton saveButton = new ExtendedButton(width / 2 - 75 - 10, height - 25, 75, 20, Component.translatable("ds.gui.dragon_editor.save"), null){
+		ExtendedButton saveButton = new ExtendedButton(width / 2 - 75 - 10, height - 25, 75, 20, Component.translatable("ds.gui.dragon_editor.save"), pButton -> {}){
 			Renderable renderButton;
 			boolean toggled;
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/CopySettingsButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/CopySettingsButton.java
@@ -47,7 +47,7 @@ public class CopySettingsButton extends ExtendedButton {
 	@Override
 	public void onPress(){
 		if(!toggled){
-			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), null){
+			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), pButton -> {}){
 				@Override
 				public void renderWidget(@NotNull final GuiGraphics guiGraphics, int p_230430_2_, int p_230430_3_, float p_230430_4_){
 					active = visible = false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonDropdownValueEntry.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonDropdownValueEntry.java
@@ -39,7 +39,7 @@ public class DragonDropdownValueEntry extends DropdownValueEntry
 	public void render(GuiGraphics guiGraphics, int pIndex, int pTop, int pLeft, int pWidth, int pHeight, int pMouseX, int pMouseY, boolean pIsMouseOver, float pPartialTicks){
 		if(button == null){
 			Component displayString = Component.literal(localeString);
-			button = new ExtendedButton(pLeft + 3, 0, pWidth - 12, pHeight + 1, displayString, null){
+			button = new ExtendedButton(pLeft + 3, 0, pWidth - 12, pHeight + 1, displayString, pButton -> {}){
 					@Override
 					public Component getMessage(){
 						return message;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
@@ -104,7 +104,7 @@ public class DragonEditorDropdownButton extends DropDownButton{
 			}
 
 			boolean finalHasBorder = hasBorder;
-			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), null){
+			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), pButton -> {}){
 				@Override
 				public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick){
 					active = visible = false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/ColorSelectorButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/ColorSelectorButton.java
@@ -30,7 +30,7 @@ public class ColorSelectorButton extends ExtendedButton {
 	private Renderable renderButton;
 
 	public ColorSelectorButton(DragonEditorScreen screen, EnumSkinLayer layer, int x, int y, int xSize, int ySize, Consumer<Double> setter){
-		super(x, y, xSize, ySize, null, null);
+		super(x, y, xSize, ySize, Component.empty(), pButton -> {});
 		this.xSize = xSize;
 		this.ySize = ySize;
 		this.setter = setter;
@@ -70,7 +70,7 @@ public class ColorSelectorButton extends ExtendedButton {
 	public void onPress(){
 		Texture text = DragonEditorHandler.getSkin(FakeClientPlayerUtils.getFakePlayer(0, screen.handler), layer, screen.preset.skinAges.get(screen.level).get().layerSettings.get(layer).get().selectedSkin, screen.handler.getType());
 		if(!toggled){
-			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), null){
+			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), pButton -> {}){
 				@Override
 				public void renderWidget(@NotNull final GuiGraphics guiGraphics, int p_230430_2_, int p_230430_3_, float p_230430_4_){
 					active = visible = false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/SkillProgressButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/SkillProgressButton.java
@@ -25,7 +25,7 @@ public class SkillProgressButton extends Button{
 	private ActiveDragonAbility ability;
 
 	public SkillProgressButton(int x, int y, int slot, AbilityScreen screen){
-		super(x, y, 16, 16, null, button -> {}, DEFAULT_NARRATION);
+		super(x, y, 16, 16, Component.empty(), button -> {}, DEFAULT_NARRATION);
 		this.slot = slot;
 		this.screen = screen;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/dropdown/DropdownValueEntry.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/dropdown/DropdownValueEntry.java
@@ -42,7 +42,7 @@ public class DropdownValueEntry extends DropdownEntry{
 	@Override
 	public void render(@NotNull GuiGraphics guiGraphics, int pIndex, int pTop, int pLeft, int pWidth, int pHeight, int pMouseX, int pMouseY, boolean pIsMouseOver, float pPartialTicks) {
 		if(button == null){
-			button = new ExtendedButton(pLeft + 3, 0, pWidth - 12, pHeight + 1, null, null){
+			button = new ExtendedButton(pLeft + 3, 0, pWidth - 12, pHeight + 1, Component.empty(), pButton -> {}){
 				@Override
 				public Component getMessage(){
 					return message;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/generic/DropDownButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/generic/DropDownButton.java
@@ -33,7 +33,7 @@ public class DropDownButton extends ExtendedButton {
 	public Component message;
 
 	public DropDownButton(int x, int y, int xSize, int ySize, String current, String[] values, Consumer<String> setter){
-		super(x, y, xSize, ySize, null, null);
+		super(x, y, xSize, ySize, Component.empty(), pButton -> {});
 		this.values = values;
 		this.setter = setter;
 		this.current = current;
@@ -134,7 +134,7 @@ public class DropDownButton extends ExtendedButton {
 			}
 
 			boolean finalHasBorder = hasBorder;
-			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), null){
+			renderButton = new ExtendedButton(0, 0, 0, 0, Component.empty(), pButton -> {}){
 				@Override
 				public void renderWidget(@NotNull final GuiGraphics guiGraphics, int p_230430_2_, int p_230430_3_, float p_230430_4_){
 					active = visible = false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/CopyEditorSettingsComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/CopyEditorSettingsComponent.java
@@ -42,7 +42,7 @@ public class CopyEditorSettingsComponent extends AbstractContainerEventHandler i
 		this.ySize = ySize;
 		this.btn = btn;
 
-		confirm = new ExtendedButton(x + xSize / 2 - 18, y + ySize - 15, 15, 15, Component.empty(), null){
+		confirm = new ExtendedButton(x + xSize / 2 - 18, y + ySize - 15, 15, 15, Component.empty(), pButton -> {}){
 			@Override
 			public void renderWidget(@NotNull final GuiGraphics guiGraphics, int mouseX, int mouseY, float partial){
 				super.renderWidget(guiGraphics, mouseX, mouseY, partial);
@@ -83,7 +83,7 @@ public class CopyEditorSettingsComponent extends AbstractContainerEventHandler i
 		};
 		confirm.setTooltip(Tooltip.create(Component.translatable("ds.gui.dragon_editor.tooltip.done")));
 
-		cancel = new ExtendedButton(x + xSize / 2 + 3, y + ySize - 15, 15, 15, Component.empty(), null){
+		cancel = new ExtendedButton(x + xSize / 2 + 3, y + ySize - 15, 15, 15, Component.empty(), pButton -> {}){
 			@Override
 			public void renderWidget(@NotNull final GuiGraphics guiGraphics, int mouseX, int mouseY, float partial){
 //				guiGraphics.pose().pushPose();

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/DragonEditorConfirmComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/DragonEditorConfirmComponent.java
@@ -37,7 +37,7 @@ public class DragonEditorConfirmComponent extends AbstractContainerEventHandler 
 		this.xSize = xSize;
 		this.ySize = ySize;
 
-		btn1 = new ExtendedButton(x + 19, y + 133, 41, 21, CommonComponents.GUI_YES, null){
+		btn1 = new ExtendedButton(x + 19, y + 133, 41, 21, CommonComponents.GUI_YES, pButton -> {}){
 			@Override
 			public void renderWidget(@NotNull final GuiGraphics guiGraphics, int mouseX, int mouseY, float partial){
 				guiGraphics.drawCenteredString(Minecraft.getInstance().font, getMessage(), getX() + getWidth() / 2, getY() + (getHeight() - 8) / 2, getFGColor());
@@ -53,7 +53,7 @@ public class DragonEditorConfirmComponent extends AbstractContainerEventHandler 
 			}
 		};
 
-		btn2 = new ExtendedButton(x + 66, y + 133, 41, 21, CommonComponents.GUI_NO, null){
+		btn2 = new ExtendedButton(x + 66, y + 133, 41, 21, CommonComponents.GUI_NO, pButton -> {}){
 			@Override
 			public void renderWidget(@NotNull final GuiGraphics guiGraphics, int mouseX, int mouseY, float partial){
 				guiGraphics.drawCenteredString(Minecraft.getInstance().font, getMessage(), getX() + getWidth() / 2, getY() + (getHeight() - 8) / 2, getFGColor());


### PR DESCRIPTION
Pressing Tab repeatedly could lead to a crash because `displayString` was unexpectedly set to `null`. This replaces all such instances with `Component.empty()`

In addition, I replaced all nearby `handler`s also set to `null` with empty lambdas. I don't think these caused any crashes otherwise, as the invoking method was overriden each time, but it's still better to not pass `null`s to `NotNull`-annotated params.