### PR TITLE
Fix fake player stuff

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/FakeClientPlayerUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/FakeClientPlayerUtils.java
@@ -22,60 +22,59 @@ import java.util.concurrent.TimeUnit;
 @EventBusSubscriber(Dist.CLIENT)
 public class FakeClientPlayerUtils {
 	private static final ConcurrentHashMap<Integer, FakeClientPlayer> FAKE_PLAYERS = new ConcurrentHashMap<>();
-	public static final ConcurrentHashMap<Integer, DragonEntity> FAKE_DRAGONS = new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<Integer, DragonEntity> FAKE_DRAGONS = new ConcurrentHashMap<>();
 
 	public static DragonEntity getFakeDragon(int index, final DragonStateHandler handler) {
-		FakeClientPlayer clientPlayer = getFakePlayer(index, handler);
+		FakeClientPlayer fakePlayer = getFakePlayer(index, handler);
 
-		FAKE_DRAGONS.computeIfAbsent(index, key -> new DragonEntity(DSEntities.DRAGON.get(), clientPlayer.level()) {
+		return FAKE_DRAGONS.computeIfAbsent(index, key -> new DragonEntity(DSEntities.DRAGON.get(), fakePlayer.level()) {
 			@Override
 			public void registerControllers(final AnimatableManager.ControllerRegistrar controllers) {
-				AnimationController<DragonEntity> ac = new AnimationController<DragonEntity>(this, "fake_player_controller", 2, state -> {
-					if (FAKE_PLAYERS.get(index).handler.refreshBody) {
-						clientPlayer.animationController.forceAnimationReset();
-						FAKE_PLAYERS.get(index).handler.refreshBody = false;
+				AnimationController<DragonEntity> controller = new AnimationController<>(this, "fake_player_controller", 2, state -> {
+					if (fakePlayer.handler.refreshBody) {
+						fakePlayer.animationController.forceAnimationReset();
+						fakePlayer.handler.refreshBody = false;
 						return PlayState.STOP;
 					}
 
-					if (getPlayer() instanceof FakeClientPlayer) {
-						if (clientPlayer.animationSupplier != null) {
-							return state.setAndContinue(RawAnimation.begin().thenLoop(clientPlayer.animationSupplier.get()));
-						}
+					if (fakePlayer.animationSupplier != null) {
+						return state.setAndContinue(RawAnimation.begin().thenLoop(fakePlayer.animationSupplier.get()));
 					}
 
 					return PlayState.STOP;
 				});
-				if (getPlayer() instanceof FakeClientPlayer fcp) {
-					fcp.animationController = ac;
-				}
-				controllers.add(ac);
+
+				fakePlayer.animationController = controller;
+				controllers.add(controller);
 			}
 
 			@Override
 			public Player getPlayer() {
-				return clientPlayer;
+				return fakePlayer;
 			}
 		});
-
-		return FAKE_DRAGONS.get(index);
 	}
 
-	public static FakeClientPlayer getFakePlayer(int num, DragonStateHandler handler){
-		FAKE_PLAYERS.computeIfAbsent(num, FakeClientPlayer::new);
-		FAKE_PLAYERS.get(num).handler = handler;
-		FAKE_PLAYERS.get(num).lastAccessed = System.currentTimeMillis();
-		return FAKE_PLAYERS.get(num);
+	public static FakeClientPlayer getFakePlayer(int index, DragonStateHandler handler) {
+		FAKE_PLAYERS.computeIfAbsent(index, FakeClientPlayer::new);
+		FAKE_PLAYERS.get(index).handler = handler;
+		FAKE_PLAYERS.get(index).lastAccessed = System.currentTimeMillis();
+		return FAKE_PLAYERS.get(index);
 	}
 
 	@SubscribeEvent
-	public static void clientTick(ClientTickEvent event){
-		FAKE_PLAYERS.forEach((i, v) -> {
-			if(System.currentTimeMillis() - v.lastAccessed >= TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES)){
-				v.remove(RemovalReason.DISCARDED);
-				FAKE_DRAGONS.get(i).remove(RemovalReason.DISCARDED);
+	public static void clientTick(ClientTickEvent event) {
+		FAKE_PLAYERS.forEach((index, player) -> {
+			if (System.currentTimeMillis() - player.lastAccessed >= TimeUnit.MILLISECONDS.convert(10, TimeUnit.MINUTES)) {
+				player.remove(RemovalReason.DISCARDED);
+				DragonEntity dragon = FAKE_DRAGONS.get(index);
 
-				FAKE_DRAGONS.remove(i);
-				FAKE_PLAYERS.remove(i);
+				if (dragon != null) {
+					dragon.remove(RemovalReason.DISCARDED);
+					FAKE_DRAGONS.remove(index);
+				}
+
+				FAKE_PLAYERS.remove(index);
 			}
 		});
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateProvider.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateProvider.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +66,7 @@ public class DragonStateProvider implements ICapabilitySerializable<CompoundTag>
 				}
 			}
 
-			if (!(entity instanceof Player)) {
+			if (!(entity instanceof Player) || /* e.g. Create Deployer */ entity instanceof FakePlayer) {
 				return LazyOptional.empty();
 			}
 


### PR DESCRIPTION
Don't fetch capabilities for Forge `FakePlayer` (e.g. Create Deployer)

Clean up `FakeClientPlayerUtils`
- `getPlayer()` returned the value outside the lambda anyway so I cleaned up the mix between using the value from the map and the value outside the lambda
- The value returned from the map should be the same anyway since the map is not accessed from anywhere else and there is no overwrite (just remove and re-add, in which case the fake dragon is also newly computed)

fix #574 