### PR TITLE
Embeddium compat + misc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,9 @@ dependencies {
 	compileOnly "mezz.jei:jei-1.21-neoforge-api:${jei_version}"
 
 	compileOnly "squeek.appleskin:appleskin-neoforge:${appleskin_version}:api"
+
+	// Test
+	implementation "curse.maven:embeddium-908741:5556146" // 1.0.7
 }
 
 tasks.withType(ProcessResources).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -127,36 +127,6 @@ tasks.withType(ProcessResources).configureEach {
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
-};
-
-subsystems {
-	parchment {
-		// The Minecraft version for which the Parchment mappings were created.
-		// This does not necessarily need to match the Minecraft version your mod targets
-		// Defaults to the value of Gradle property neogradle.subsystems.parchment.minecraftVersion
-		minecraftVersion = minecraft_version
-
-		// The version of Parchment mappings to apply.
-		// See https://parchmentmc.org/docs/getting-started for a list.
-		// Defaults to the value of Gradle property neogradle.subsystems.parchment.mappingsVersion
-		mappingsVersion = mapping_version
-
-		// Overrides the full Maven coordinate of the Parchment artifact to use
-		// This is computed from the minecraftVersion and mappingsVersion properties by default.
-		// If you set this property explicitly, minecraftVersion and mappingsVersion will be ignored.
-		// The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.parchmentArtifact
-		// parchmentArtifact = "org.parchmentmc.data:parchment-$minecraftVersion:$mappingsVersion:checked@zip"
-
-		// Set this to false if you don't want the https://maven.parchmentmc.org/ repository to be added automatically when
-		// applying Parchment mappings is enabled
-		// The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.addRepository
-		// addRepository = true
-
-		// Can be used to explicitly disable this subsystem. By default, it will be enabled automatically as soon
-		// as parchmentArtifact or minecraftVersion and mappingsVersion are set.
-		// The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.enabled
-		// enabled = true
-	}
 }
 
 // IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 	compileOnly "squeek.appleskin:appleskin-neoforge:${appleskin_version}:api"
 
 	// Test
-	implementation "curse.maven:embeddium-908741:5556146" // 1.0.7
+//	implementation "curse.maven:embeddium-908741:5556146" // 1.0.7
 }
 
 tasks.withType(ProcessResources).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,8 @@ jei_version=19.5.3.67
 appleskin_version=mc1.21-3.0.5
 
 # Mappings
-mapping_version=2024.06.23
+neogradle.subsystems.parchment.minecraftVersion=1.21
+neogradle.subsystems.parchment.mappingsVersion=2024.07.07
 
 # GitHub action
 java_version=21

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/emotes/EmoteMenuHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/emotes/EmoteMenuHandler.java
@@ -405,19 +405,6 @@ public class EmoteMenuHandler {
 
 					return !hasAge;
 				}
-
-				//TODO Add this when alternate models are added
-				//				if(em.requirements.model != null){
-				//					boolean hasModel = false;
-				//					for(String t : em.requirements.model){
-				//						if(t.toLowerCase().equals(handler.getModel().name.toLowerCase())){
-				//							hasModel = true;
-				//							break;
-				//						}
-				//					}
-				//
-				//					if(!hasModel) return true;
-				//				}
 			}
 
 			return false;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/hud/GrowthHUD.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/hud/GrowthHUD.java
@@ -100,13 +100,13 @@ public class GrowthHUD {
 				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_" + num + ".png"));
 				RenderingUtils.drawTexturedCircle(guiGraphics, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, 6, nextProgess, -0.5);
 
-				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_" + handler.getTypeName().toLowerCase() + ".png"));
+				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_" + handler.getTypeNameLowerCase() + ".png"));
 				RenderingUtils.drawTexturedCircle(guiGraphics, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, 6, progress, -0.5);
 			} else if (increment < 0) {
 				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_3.png"));
 				RenderingUtils.drawTexturedCircle(guiGraphics, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, 6, progress, -0.5);
 
-				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_" + handler.getTypeName().toLowerCase() + ".png"));
+				RenderSystem.setShaderTexture(0, getOrCreate("textures/gui/growth/circle_" + handler.getTypeNameLowerCase() + ".png"));
 				RenderingUtils.drawTexturedCircle(guiGraphics, circleX + radius, circleY + radius, radius, 0.5, 0.5, 0.5, 6, nextProgess, -0.5);
 			}
 
@@ -117,7 +117,7 @@ public class GrowthHUD {
 
 			guiGraphics.pose().pushPose();
 			guiGraphics.pose().translate(0, 0, 300);
-			guiGraphics.blit(getOrCreate("textures/gui/growth/growth_" + handler.getTypeName().toLowerCase() + "_" + (handler.getLevel().ordinal() + 1) + ".png"), circleX + 6, circleY + 6, 0, 0, 20, 20, 20, 20);
+			guiGraphics.blit(getOrCreate("textures/gui/growth/growth_" + handler.getTypeNameLowerCase() + "_" + (handler.getLevel().ordinal() + 1) + ".png"), circleX + 6, circleY + 6, 0, 0, 20, 20, 20, 20);
 			guiGraphics.pose().popPose();
 		}
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/DragonInventoryScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/DragonInventoryScreen.java
@@ -82,7 +82,7 @@ public class DragonInventoryScreen extends EffectRenderingInventoryScreen<Dragon
 	}
 
 	private static String createTextureKey(final AbstractDragonType type, final String textureType, final String addition) {
-		return textureType + "_" + type.getTypeName().toLowerCase() + addition;
+		return textureType + "_" + type.getTypeNameLowerCase() + addition;
 	}
 
 	public DragonInventoryScreen(DragonContainer screenContainer, Inventory inv, Component titleIn){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -163,7 +163,7 @@ public class DragonEditorScreen extends Screen {
 			int i = 0;
 			for(EnumSkinLayer layers : EnumSkinLayer.values()){
 				String name = layers.name;
-				SkinsScreen.drawNonShadowLineBreak(guiGraphics, font, Component.translatable("ds.gui.dragon_editor.part." + name.toLowerCase()), (i < 5 ? width / 2 - 100 - 100 : width / 2 + 83) + 45, guiTop + 10 + (i >= 5 ? (i - 5) * 30 : i * 30) - 12, DyeColor.WHITE.getTextColor());
+				SkinsScreen.drawNonShadowLineBreak(guiGraphics, font, Component.translatable("ds.gui.dragon_editor.part." + name.toLowerCase(Locale.ENGLISH)), (i < 5 ? width / 2 - 100 - 100 : width / 2 + 83) + 45, guiTop + 10 + (i >= 5 ? (i - 5) * 30 : i * 30) - 12, DyeColor.WHITE.getTextColor());
 				i++;
 			}
 		}
@@ -209,7 +209,7 @@ public class DragonEditorScreen extends Screen {
 	public SkinPreset save(){
 		SkinPreset newPreset = new SkinPreset();
 		newPreset.deserializeNBT(Minecraft.getInstance().player.registryAccess(), preset.serializeNBT(Minecraft.getInstance().player.registryAccess()));
-		String type = dragonType != null ? dragonType.getTypeName().toUpperCase() : null;
+		String type = dragonType != null ? dragonType.getTypeNameUpperCase() : null;
 
 		DragonEditorRegistry.getSavedCustomizations().skinPresets.computeIfAbsent(type, key -> new HashMap<>());
 		DragonEditorRegistry.getSavedCustomizations().skinPresets.get(type).put(currentSelected, newPreset);
@@ -255,7 +255,7 @@ public class DragonEditorScreen extends Screen {
 			level = DragonLevel.NEWBORN;
 		}
 
-		String type = dragonType.getTypeName().toUpperCase();
+		String type = dragonType.getTypeNameUpperCase();
 
 		DragonEditorRegistry.getSavedCustomizations().current.computeIfAbsent(type, key -> new HashMap<>());
 		DragonEditorRegistry.getSavedCustomizations().current.get(type).putIfAbsent(level, 0);
@@ -317,8 +317,8 @@ public class DragonEditorScreen extends Screen {
 
 		int maxWidth = -1;
 
-		for(EnumSkinLayer layers : EnumSkinLayer.values()){
-			String name = layers.name().substring(0, 1).toUpperCase(Locale.ROOT) + layers.name().toLowerCase().substring(1).replace("_", " ");
+		for (EnumSkinLayer layer : EnumSkinLayer.values()) {
+			String name = layer.getNameUpperCase().charAt(0) + layer.getNameLowerCase().substring(1).replace("_", " ");
 			maxWidth = (int)Math.max(maxWidth, font.width(name) * 1.45F);
 		}
 
@@ -520,11 +520,6 @@ public class DragonEditorScreen extends Screen {
 				return !text.random;
 			});
 
-			//if (!isEditor) {
-			//	int bodytype = minecraft.player.getRandom().nextInt(DragonBodies.ORDER.length);
-			//	dragonBody = DragonBodies.bodyMappings.get(DragonBodies.ORDER[bodytype].toLowerCase()).get();
-			//}
-
 			for(EnumSkinLayer layer : EnumSkinLayer.values()){
 				ArrayList<String> keys = DragonEditorHandler.getKeys(FakeClientPlayerUtils.getFakePlayer(0, HANDLER), layer);
 
@@ -609,8 +604,8 @@ public class DragonEditorScreen extends Screen {
 		if (currentSelected != lastSelected) {
 			preset = new SkinPreset();
 
-			if (DragonEditorRegistry.getSavedCustomizations().skinPresets.containsKey(dragonType.getTypeName().toUpperCase())) {
-				preset.deserializeNBT(Minecraft.getInstance().player.registryAccess(), DragonEditorRegistry.getSavedCustomizations().skinPresets.get(dragonType.getTypeName().toUpperCase()).get(currentSelected).serializeNBT(Minecraft.getInstance().player.registryAccess()));
+			if (DragonEditorRegistry.getSavedCustomizations().skinPresets.containsKey(dragonType.getTypeNameUpperCase())) {
+				preset.deserializeNBT(Minecraft.getInstance().player.registryAccess(), DragonEditorRegistry.getSavedCustomizations().skinPresets.get(dragonType.getTypeNameUpperCase()).get(currentSelected).serializeNBT(Minecraft.getInstance().player.registryAccess()));
 			}
 			HANDLER.getSkinData().skinPreset = preset;
 		}
@@ -648,7 +643,7 @@ public class DragonEditorScreen extends Screen {
 			minecraft.player.level().playSound(minecraft.player, minecraft.player.blockPosition(), SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, 1, 0.7f);
 
 			if(!cap.isDragon() || dragonWouldChange(cap)){
-				minecraft.player.sendSystemMessage(Component.translatable("ds." + dragonType.getTypeName().toLowerCase() + "_dragon_choice"));
+				minecraft.player.sendSystemMessage(Component.translatable("ds." + dragonType.getTypeNameLowerCase() + "_dragon_choice"));
 
 				if(dragonType == null && cap.getType() != null){
 					DragonCommand.reInsertClawTools(minecraft.player, cap);
@@ -685,17 +680,15 @@ public class DragonEditorScreen extends Screen {
 
 	@Override
 	public boolean mouseDragged(double pMouseX, double pMouseY, int pButton, double pDragX, double pDragY){
-		if(!super.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY)){
-			if(dragonRender != null && dragonRender.isMouseOver(pMouseX, pMouseY)){
-				return dragonRender.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
-			}
+		if(dragonRender != null && dragonRender.isMouseOver(pMouseX, pMouseY)){
+			return dragonRender.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
 		}
 
-		return false;
+		return super.mouseDragged(pMouseX, pMouseY, pButton, pDragX, pDragY);
 	}
 
 	public static String partToTranslation(final String part) {
-		String text = "ds.skin_part." + DragonEditorScreen.HANDLER.getTypeName().toLowerCase(Locale.ROOT) + "." + part.toLowerCase(Locale.ROOT);
+		String text = "ds.skin_part." + DragonEditorScreen.HANDLER.getTypeNameLowerCase() + "." + part.toLowerCase(Locale.ENGLISH);
 
 		if (I18n.exists(text)) {
 			return text;
@@ -705,6 +698,6 @@ public class DragonEditorScreen extends Screen {
 	}
 
 	public static String partToTechnical(final String part) {
-		return part.replace("ds.skin_part.", "").replace(DragonEditorScreen.HANDLER.getTypeName().toLowerCase(Locale.ROOT) + ".", "");
+		return part.replace("ds.skin_part.", "").replace(DragonEditorScreen.HANDLER.getTypeNameLowerCase() + ".", "");
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonBodyButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonBodyButton.java
@@ -25,7 +25,7 @@ public class DragonBodyButton extends Button {
 				dragonEditorScreen.update();
 			}
 		}, DEFAULT_NARRATION);
-		location = ResourceLocation.fromNamespaceAndPath(MODID, "textures/gui/body_type_icon_" + dragonEditorScreen.dragonType.getTypeName().toLowerCase() + ".png");
+		location = ResourceLocation.fromNamespaceAndPath(MODID, "textures/gui/body_type_icon_" + dragonEditorScreen.dragonType.getTypeNameLowerCase() + ".png");
 		this.dragonEditorScreen = dragonEditorScreen;
 		this.dragonBody = dragonBody;
 		this.pos = pos;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.NotNull;
 public class DragonEditorDropdownButton extends DropDownButton{
 	private final DragonEditorScreen dragonEditorScreen;
 	private final EnumSkinLayer layers;
-	private final String dragonType;
 
 	public DragonEditorDropdownButton(DragonEditorScreen dragonEditorScreen, int x, int y, int xSize, int ySize, String current, String[] values, EnumSkinLayer layers){
 		super(x, y, xSize, ySize, current, values, selected -> {
@@ -36,7 +35,6 @@ public class DragonEditorDropdownButton extends DropDownButton{
 		});
 		this.dragonEditorScreen = dragonEditorScreen;
 		this.layers = layers;
-		this.dragonType = DragonEditorScreen.HANDLER.getTypeName().toLowerCase();
 	}
 
 	@Override
@@ -65,6 +63,10 @@ public class DragonEditorDropdownButton extends DropDownButton{
     @Override
 	public void onPress(){
 		Screen screen = Minecraft.getInstance().screen;
+
+		if (screen == null) {
+			return;
+		}
 
 		if(!toggled){
 			int offset = screen.height - (getY() + height + 80);
@@ -129,10 +131,8 @@ public class DragonEditorDropdownButton extends DropDownButton{
 				settings.hue = text.average_hue;
 			}
 
-			screen.children().removeIf(s -> s == list);
-			screen.children().removeIf(s -> s == renderButton);
-			screen.renderables.removeIf(s -> s == list);
-			screen.renderables.removeIf(s -> s == renderButton);
+			screen.children().removeIf(s -> s == list || s == renderButton);
+			screen.renderables.removeIf(s -> s == list || s == renderButton);
 		}
 
 		toggled = !toggled;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorSlotButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorSlotButton.java
@@ -24,8 +24,8 @@ public class DragonEditorSlotButton extends Button{
 	@Override
 	public void onPress(){
 		if(screen.dragonType != null){
-			DragonEditorRegistry.getSavedCustomizations().skinPresets.computeIfAbsent(screen.dragonType.getTypeName().toUpperCase(), t -> new HashMap<>());
-			DragonEditorRegistry.getSavedCustomizations().skinPresets.get(screen.dragonType.getTypeName().toUpperCase()).put(screen.currentSelected, screen.preset);
+			DragonEditorRegistry.getSavedCustomizations().skinPresets.computeIfAbsent(screen.dragonType.getTypeNameUpperCase(), t -> new HashMap<>());
+			DragonEditorRegistry.getSavedCustomizations().skinPresets.get(screen.dragonType.getTypeNameUpperCase()).put(screen.currentSelected, screen.preset);
 		}
 
 		screen.currentSelected = num - 1;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/AltarTypeButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/AltarTypeButton.java
@@ -86,7 +86,7 @@ public class AltarTypeButton extends Button {
 		boolean atTheTopOrBottom = mouseY > getY() + 6 && mouseY < getY() + 26 || mouseY > getY() + 133 && mouseY < getY() + 153;
 
 		if (isHovered() && atTheTopOrBottom) {
-			guiGraphics.renderComponentTooltip(Minecraft.getInstance().font, altarDragonInfoLocalized(type == null ? "human" : type.getTypeName().toLowerCase() + "_dragon", type == null ? Collections.emptyList() : DragonFoodHandler.getEdibleFoods(type)), mouseX, mouseY);
+			guiGraphics.renderComponentTooltip(Minecraft.getInstance().font, altarDragonInfoLocalized(type == null ? "human" : type.getTypeNameLowerCase() + "_dragon", type == null ? Collections.emptyList() : DragonFoodHandler.getEdibleFoods(type)), mouseX, mouseY);
 		}
 
 		RenderSystem.setShaderTexture(0, BACKGROUND_TEXTURE);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/generic/DropDownButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/generic/DropDownButton.java
@@ -6,9 +6,6 @@ import by.dragonsurvivalteam.dragonsurvival.client.gui.widgets.buttons.dropdown.
 import by.dragonsurvivalteam.dragonsurvival.client.gui.widgets.buttons.dropdown.DropdownValueEntry;
 import by.dragonsurvivalteam.dragonsurvival.mixins.AccessorScreen;
 import com.mojang.blaze3d.systems.RenderSystem;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Consumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
@@ -20,6 +17,10 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.util.FormattedCharSequence;
 import net.neoforged.neoforge.client.gui.widget.ExtendedButton;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 public class DropDownButton extends ExtendedButton {
 	public static final int maxItems = 4;
@@ -47,19 +48,19 @@ public class DropDownButton extends ExtendedButton {
 
 	@Override
 	public void renderWidget(@NotNull final GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-		// TODO :: Is this safe?
-		if(toggled && (!visible || !isHoveredOrFocused() && !list.isMouseOver(mouseX, mouseY))){
-			toggled = false;
-			Screen screen = Minecraft.getInstance().screen;
-			screen.children().removeIf(s -> s == list);
-			screen.children().removeIf(s -> s == renderButton);
-			screen.renderables.removeIf(s -> s == list);
-			screen.renderables.removeIf(s -> s == renderButton);
+		Screen screen = Minecraft.getInstance().screen;
+
+		if (screen == null) {
+			return;
 		}
 
+		if(toggled && (!visible || !isHoveredOrFocused() && !list.isMouseOver(mouseX, mouseY))){
+			toggled = false;
+			screen.children.removeIf(s -> s == list || s == renderButton);
+			screen.renderables.removeIf(s -> s == list || s == renderButton);
+		}
 
 		if(toggled && list != null){
-			Screen screen = Minecraft.getInstance().screen;
 			int offset = screen.height - (getY() + height + 80);
 			list.reposition(getX(), getY() + height + Math.min(offset, 0), width, (int)(Math.max(1, Math.min(values.length, maxItems)) * (height * 1.5f)));
 		}
@@ -96,6 +97,10 @@ public class DropDownButton extends ExtendedButton {
 	@Override
 	public void onPress(){
 		Screen screen = Minecraft.getInstance().screen;
+
+		if (screen == null) {
+			return;
+		}
 
 		if(!toggled){
 			int offset = screen.height - (getY() + height + 80);
@@ -153,10 +158,8 @@ public class DropDownButton extends ExtendedButton {
 			((AccessorScreen)screen).children().add(renderButton);
 			screen.renderables.add(renderButton);
 		}else{
-			screen.children().removeIf(s -> s == list);
-			screen.children().removeIf(s -> s == renderButton);
-			screen.renderables.removeIf(s -> s == list);
-			screen.renderables.removeIf(s -> s == renderButton);
+			screen.children().removeIf(s -> s == list || s == renderButton);
+			screen.renderables.removeIf(s -> s == list || s == renderButton);
 		}
 
 		toggled = !toggled;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
@@ -111,7 +111,7 @@ public class DragonModel extends GeoModel<DragonEntity> {
 			}
 
 			if (handler.getSkinData().blankSkin) {
-				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/blank_skin_" + handler.getTypeName().toLowerCase(Locale.ROOT) + ".png");
+				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/blank_skin_" + handler.getTypeNameLowerCase() + ".png");
 			}
 
 			if (ageGroup.defaultSkin) {
@@ -119,7 +119,7 @@ public class DragonModel extends GeoModel<DragonEntity> {
 					return currentTexture;
 				}
 
-				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/" + handler.getTypeName().toLowerCase(Locale.ROOT) + "_" + handler.getLevel().name.toLowerCase(Locale.ROOT) + ".png");
+				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/" + handler.getTypeNameLowerCase() + "_" + handler.getLevel().getNameLowerCase() + ".png");
 			}
 
 			if (handler.getSkinData().isCompiled && currentTexture == null) {
@@ -148,7 +148,7 @@ public class DragonModel extends GeoModel<DragonEntity> {
 			DragonStateHandler handler = DragonStateProvider.getOrGenerateHandler(dragon.getPlayer());
 			AbstractDragonBody body = handler.getBody();
 			if (body != null) {
-				return ResourceLocation.fromNamespaceAndPath(MODID, String.format("animations/dragon_%s.json", body.getBodyName().toLowerCase()));
+				return ResourceLocation.fromNamespaceAndPath(MODID, String.format("animations/dragon_%s.json", body.getBodyNameLowerCase()));
 			}
 		}
 		return ResourceLocation.fromNamespaceAndPath(MODID, "animations/dragon_center.json");

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/VisionHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/VisionHandler.java
@@ -1,5 +1,6 @@
 package by.dragonsurvivalteam.dragonsurvival.client.render;
 
+import by.dragonsurvivalteam.dragonsurvival.mixins.client.LiquidBlockRendererMixin;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSEffects;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
@@ -21,12 +22,12 @@ public class VisionHandler {
     public static void onRenderFog(ViewportEvent.RenderFog event) {
         if (hasLavaVision() && event.getCamera().getFluidInCamera() == FogType.LAVA) {
             event.setNearPlaneDistance(0);
-            event.setFarPlaneDistance(event.getRenderer().getRenderDistance() * 0.2f);
+            event.setFarPlaneDistance(event.getRenderer().getRenderDistance() * 0.5f);
             event.setCanceled(true);
         }
     }
 
-    /** The alpha change in {@link by.dragonsurvivalteam.dragonsurvival.mixins.client.LiquidBlockRendererMixin} requires the drawn blocks to be uncached and be re-rendered */
+    /** The alpha change in {@link LiquidBlockRendererMixin} requires the drawn blocks to be uncached and be re-rendered */
     @SubscribeEvent
     public static void onRenderWorldLastEvent(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) {
@@ -73,5 +74,17 @@ public class VisionHandler {
         }
 
         return false;
+    }
+
+    public static boolean hasVision(final VisionType type) {
+        return switch (type) {
+            case WATER -> hasWaterVision();
+            case LAVA -> hasLavaVision();
+        };
+    }
+
+    public enum VisionType {
+        WATER,
+        LAVA
     }
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonGlowLayerRenderer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonGlowLayerRenderer.java
@@ -51,14 +51,14 @@ public class DragonGlowLayerRenderer extends GeoRenderLayer<DragonEntity> {
 
 		ResourceLocation glowTexture = DragonSkins.getGlowTexture(player, handler.getType(), handler.getLevel());
 
-		if (glowTexture == null || glowTexture.getPath().contains("/" + handler.getTypeName().toLowerCase() + "_")) {
+		if (glowTexture == null || glowTexture.getPath().contains("/" + handler.getTypeNameLowerCase() + "_")) {
 			if (dragonRenderer.glowTexture != null) {
 				glowTexture = dragonRenderer.glowTexture;
 			}
 		}
 
 		if (glowTexture == null && handler.getSkinData().skinPreset.skinAges.get(handler.getLevel()).get().defaultSkin) {
-			ResourceLocation location = ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/" + handler.getTypeName().toLowerCase(Locale.ROOT) + "_" + handler.getLevel().name.toLowerCase(Locale.ROOT) + "_glow.png");
+			ResourceLocation location = ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/" + handler.getTypeNameLowerCase() + "_" + handler.getLevel().getNameLowerCase() + "_glow.png");
 
 			if (Minecraft.getInstance().getResourceManager().getResource(location).isPresent()) {
 				glowTexture = location;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorHandler.java
@@ -37,10 +37,10 @@ public class DragonEditorHandler{
 
 		if(layer == EnumSkinLayer.BASE && (key.equalsIgnoreCase("Skin") || key.equalsIgnoreCase(SkinCap.defaultSkinValue))){
 			DragonStateHandler handler = DragonStateProvider.getOrGenerateHandler(player);
-			return getSkinTexture(player, layer, type.getTypeName().toLowerCase() + "_base_" + handler.getLevel().ordinal(), type);
+			return getSkinTexture(player, layer, type.getSubtypeNameLowerCase() + "_base_" + handler.getLevel().ordinal(), type);
 		}
 
-		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(layer, new Texture[0]);
+		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(layer, new Texture[0]);
 
 		for(Texture texture : texts){
 			if(Objects.equals(texture.key, key)){
@@ -57,10 +57,10 @@ public class DragonEditorHandler{
 		}
 
 		if(layer == EnumSkinLayer.BASE && (key.equalsIgnoreCase("Skin") || key.equalsIgnoreCase(SkinCap.defaultSkinValue))){
-			return getSkin(player, layer, type.getTypeName().toLowerCase() + "_base_" + DragonUtils.getDragonLevel(player).ordinal(), type);
+			return getSkin(player, layer, type.getTypeNameLowerCase() + "_base_" + DragonUtils.getDragonLevel(player).ordinal(), type);
 		}
 
-		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(layer, new Texture[0]);
+		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(layer, new Texture[0]);
 
 		for(Texture texture : texts){
 			if(Objects.equals(texture.key, key)){
@@ -78,7 +78,7 @@ public class DragonEditorHandler{
 
 		ArrayList<String> list = new ArrayList<>();
 
-		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(layers, new Texture[0]);
+		Texture[] texts = DragonEditorRegistry.CUSTOMIZATIONS.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(layers, new Texture[0]);
 		for(Texture texture : texts){
 			if (texture.bodies == null || Arrays.asList(texture.bodies).contains(body.toString())) {
 				list.add(texture.key);
@@ -204,7 +204,9 @@ public class DragonEditorHandler{
 			//	file = new File(file.getPath(), key.toString().replace(":", "_") + ".png");
 			//	image.writeToFile(file);
 			//}
-			if (Minecraft.getInstance().getTextureManager().getTexture(key) instanceof DynamicTexture texture) {
+
+			// the other 'getTexture' call tries to register the texture immediately
+			if (Minecraft.getInstance().getTextureManager().getTexture(key, null) instanceof DynamicTexture texture) {
 				texture.setPixels(image);
 				texture.upload();
 			} else {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorRegistry.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorRegistry.java
@@ -15,6 +15,7 @@ import by.dragonsurvivalteam.dragonsurvival.util.GsonFactory;
 import com.google.gson.Gson;
 import java.io.*;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
@@ -41,7 +42,7 @@ public class DragonEditorRegistry{
 	public static File savedFile;
 
 	public static String getDefaultPart(AbstractDragonType type, DragonLevel level, EnumSkinLayer layer){
-		return defaultSkinValues.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(level, new HashMap<>()).getOrDefault(layer, SkinCap.defaultSkinValue);
+		return defaultSkinValues.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(level, new HashMap<>()).getOrDefault(layer, SkinCap.defaultSkinValue);
 	}
 
 	public static SavedSkinPresets getSavedCustomizations(){
@@ -90,7 +91,7 @@ public class DragonEditorRegistry{
 				savedCustomizations = new SavedSkinPresets();
 
 				for(String t : DragonTypes.getTypes()){
-					String type = t.toUpperCase();
+					String type = t.toUpperCase(Locale.ENGLISH);
 					savedCustomizations.skinPresets.computeIfAbsent(type, b -> new HashMap<>());
 					savedCustomizations.current.computeIfAbsent(type, b -> new HashMap<>());
 
@@ -142,9 +143,9 @@ public class DragonEditorRegistry{
 
 			try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
 				DragonEditorObject je = gson.fromJson(reader, DragonEditorObject.class);
-				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.SEA.getTypeName().toUpperCase(), type -> new HashMap<>());
-				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.CAVE.getTypeName().toUpperCase(), type -> new HashMap<>());
-				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.FOREST.getTypeName().toUpperCase(), type -> new HashMap<>());
+				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.SEA.getTypeNameUpperCase(), type -> new HashMap<>());
+				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.CAVE.getTypeNameUpperCase(), type -> new HashMap<>());
+				CUSTOMIZATIONS.computeIfAbsent(DragonTypes.FOREST.getTypeNameUpperCase(), type -> new HashMap<>());
 
 				dragonType(DragonTypes.SEA, je.sea_dragon);
 				dragonType(DragonTypes.CAVE, je.cave_dragon);
@@ -169,7 +170,7 @@ public class DragonEditorRegistry{
 							key.key = key.key.substring(0, key.key.lastIndexOf("."));
 						}
 					}
-					CUSTOMIZATIONS.get(type.getTypeName().toUpperCase()).put(layer, keys);
+					CUSTOMIZATIONS.get(type.getTypeNameUpperCase()).put(layer, keys);
 				});
 			}
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/EnumSkinLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/EnumSkinLayer.java
@@ -1,6 +1,8 @@
 package by.dragonsurvivalteam.dragonsurvival.client.skin_editor_system;
 
-public enum EnumSkinLayer{
+import java.util.Locale;
+
+public enum EnumSkinLayer {
 	BASE("Base", true),
 	BOTTOM("Bottom", true),
 	EYES("Eyes", true),
@@ -21,8 +23,16 @@ public enum EnumSkinLayer{
 	public final String name;
 	public final boolean base;
 
-	EnumSkinLayer(String name, boolean base){
+	EnumSkinLayer(final String name, boolean base) {
 		this.name = name;
 		this.base = base;
+	}
+
+	public String getNameUpperCase() {
+		return name.toUpperCase(Locale.ENGLISH);
+	}
+
+	public String getNameLowerCase() {
+		return name.toLowerCase(Locale.ENGLISH);
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/SkinPortingSystem.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/SkinPortingSystem.java
@@ -7,6 +7,8 @@ import by.dragonsurvivalteam.dragonsurvival.client.skin_editor_system.objects.Sk
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.DragonTypes;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import java.util.HashMap;
+import java.util.Locale;
+
 import net.neoforged.neoforge.common.util.Lazy;
 
 public class SkinPortingSystem {
@@ -26,8 +28,8 @@ public class SkinPortingSystem {
                         LayerSettings settings = sag.layerSettings.get(layer).get();
 
                         String part = DragonEditorRegistry.getDefaultPart(DragonTypes.getStatic(type), level, layer);
-                        EnumSkinLayer trueLayer = EnumSkinLayer.valueOf(layer.name.toUpperCase());
-                        HashMap<EnumSkinLayer, DragonEditorObject.Texture[]> hm = DragonEditorRegistry.CUSTOMIZATIONS.get(type.toUpperCase());
+                        EnumSkinLayer trueLayer = EnumSkinLayer.valueOf(layer.getNameUpperCase());
+                        HashMap<EnumSkinLayer, DragonEditorObject.Texture[]> hm = DragonEditorRegistry.CUSTOMIZATIONS.get(type.toUpperCase(Locale.ENGLISH));
                         if (hm != null) {
                             DragonEditorObject.Texture[] texts = hm.get(trueLayer);
                             if (texts != null) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/objects/SkinPreset.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/objects/SkinPreset.java
@@ -68,8 +68,8 @@ public class SkinPreset implements INBTSerializable<CompoundTag> {
 			this(level);
 			for(EnumSkinLayer layer : EnumSkinLayer.values()){
 				String part = DragonEditorRegistry.getDefaultPart(type, level, layer);
-				EnumSkinLayer trueLayer = EnumSkinLayer.valueOf(layer.name.toUpperCase());
-				HashMap<EnumSkinLayer, DragonEditorObject.Texture[]> hm = DragonEditorRegistry.CUSTOMIZATIONS.get(type.getTypeName().toUpperCase());
+				EnumSkinLayer trueLayer = EnumSkinLayer.valueOf(layer.getNameUpperCase());
+				HashMap<EnumSkinLayer, DragonEditorObject.Texture[]> hm = DragonEditorRegistry.CUSTOMIZATIONS.get(type.getTypeNameUpperCase());
 				if (hm != null) {
 					DragonEditorObject.Texture[] texts = hm.get(trueLayer);
 					if (texts != null) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/DragonSkins.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/DragonSkins.java
@@ -89,7 +89,7 @@ public class DragonSkins{
 		String[] text = ArrayUtils.addAll(new String[]{playerKey}, extra);
 
 		String resourceName = StringUtils.join(text, "_");
-		ResourceLocation resourceLocation = ResourceLocation.fromNamespaceAndPath(MODID, resourceName.toLowerCase(Locale.ROOT));
+		ResourceLocation resourceLocation = ResourceLocation.fromNamespaceAndPath(MODID, resourceName.toLowerCase(Locale.ENGLISH));
 
 		try (SimpleTexture simpleTexture = new SimpleTexture(resourceLocation)) {
 			if (Minecraft.getInstance().getTextureManager().getTexture(resourceLocation, simpleTexture) != simpleTexture) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/ClientFluidTypeExtensionsProxy.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/ClientFluidTypeExtensionsProxy.java
@@ -1,0 +1,64 @@
+package by.dragonsurvivalteam.dragonsurvival.client.util;
+
+import by.dragonsurvivalteam.dragonsurvival.client.render.VisionHandler;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.material.FluidState;
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import org.jetbrains.annotations.NotNull;
+
+public class ClientFluidTypeExtensionsProxy implements IClientFluidTypeExtensions {
+    private final IClientFluidTypeExtensions original;
+    private final VisionHandler.VisionType type;
+
+    public ClientFluidTypeExtensionsProxy(final IClientFluidTypeExtensions original, final VisionHandler.VisionType type) {
+        this.original = original;
+        this.type = type;
+    }
+
+    @Override
+    public @NotNull ResourceLocation getStillTexture() {
+        return original.getStillTexture();
+    }
+
+    @Override
+    public @NotNull ResourceLocation getFlowingTexture() {
+        return original.getFlowingTexture();
+    }
+
+    @Override
+    public ResourceLocation getOverlayTexture() {
+        return original.getOverlayTexture();
+    }
+
+    @Override
+    public ResourceLocation getRenderOverlayTexture(@NotNull final Minecraft minecraft) {
+        return original.getRenderOverlayTexture(minecraft);
+    }
+
+    @Override
+    public int getTintColor() {
+        int color = original.getTintColor();
+
+        if (VisionHandler.hasVision(type)) {
+            // 0x5A is 90 which is roughly the result of 255 * 0.35
+            return (color /* Remove alpha */ & 0x00FFFFFF) /* Add custom alpha */ | 0x5A000000;
+        }
+
+        return color;
+    }
+
+    @Override
+    public int getTintColor(@NotNull final FluidState state, @NotNull final BlockAndTintGetter getter, @NotNull final BlockPos position) {
+        int color = original.getTintColor(state, getter, position);
+
+        if (VisionHandler.hasVision(type)) {
+            // 0x5A is 90 which is roughly the result of 255 * 0.35
+            return (color /* Remove alpha */ & 0x00FFFFFF) /* Add custom alpha */ | 0x5A000000;
+        }
+
+        return color;
+    }
+}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/ClientFluidTypeExtensionsWrapper.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/ClientFluidTypeExtensionsWrapper.java
@@ -9,11 +9,11 @@ import net.minecraft.world.level.material.FluidState;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import org.jetbrains.annotations.NotNull;
 
-public class ClientFluidTypeExtensionsProxy implements IClientFluidTypeExtensions {
+public class ClientFluidTypeExtensionsWrapper implements IClientFluidTypeExtensions {
     private final IClientFluidTypeExtensions original;
     private final VisionHandler.VisionType type;
 
-    public ClientFluidTypeExtensionsProxy(final IClientFluidTypeExtensions original, final VisionHandler.VisionType type) {
+    public ClientFluidTypeExtensionsWrapper(final IClientFluidTypeExtensions original, final VisionHandler.VisionType type) {
         this.original = original;
         this.type = type;
     }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
@@ -20,6 +20,8 @@ import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
 import java.util.List;
+import java.util.Locale;
+
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.commands.arguments.selector.EntitySelector;
@@ -42,7 +44,7 @@ public class DragonCommand{
 		ArgumentCommandNode<CommandSourceStack, String> dragonType = argument("dragon_type", StringArgumentType.string()).suggests((context, builder) -> {
 			SuggestionsBuilder builder1 = null;
 			for(String value : DragonTypes.getAllSubtypes()){
-				String val = value.toLowerCase();
+				String val = value.toLowerCase(Locale.ENGLISH);
 				builder1 = builder1 == null ? builder.suggest(val) : builder1.suggest(val);
 			}
 			builder1 = builder1 == null ? builder.suggest("human") : builder1.suggest("human");
@@ -58,7 +60,7 @@ public class DragonCommand{
 		ArgumentCommandNode<CommandSourceStack, String> dragonBody = argument("dragon_body", StringArgumentType.string()).suggests((context, builder) -> {
 			SuggestionsBuilder sgBuilder = null;
 			for (String val : DragonBodies.getBodies()) {
-				sgBuilder = sgBuilder == null ? builder.suggest(val) : sgBuilder.suggest(val.toLowerCase());
+				sgBuilder = sgBuilder == null ? builder.suggest(val) : sgBuilder.suggest(val.toLowerCase(Locale.ENGLISH));
 			}
 
 			return sgBuilder.buildFuture();

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -12,6 +12,8 @@ import by.dragonsurvivalteam.dragonsurvival.registry.DSModifiers;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonUtils;
 import by.dragonsurvivalteam.dragonsurvival.util.Functions;
+
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -174,6 +176,14 @@ public class DragonStateHandler extends EntityStateHandler {
 		}
 
 		return dragonType.getTypeName();
+	}
+
+	public String getTypeNameLowerCase() {
+		if (dragonType == null) {
+			return "human";
+		}
+
+		return dragonType.getTypeNameLowerCase();
 	}
 
 	public String getSubtypeName() {
@@ -347,7 +357,7 @@ public class DragonStateHandler extends EntityStateHandler {
 			return ItemStack.EMPTY;
 		}
 
-		String tierPath = tiers.name().toLowerCase() + "_";
+		String tierPath = tiers.name().toLowerCase(Locale.ENGLISH) + "_";
 		tierPath = tierPath.replace("wood", "wooden");
 
 		Item item = switch (toolSlot) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/AbstractDragonBody.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/AbstractDragonBody.java
@@ -3,6 +3,8 @@ package by.dragonsurvivalteam.dragonsurvival.common.dragon_types;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.NBTInterface;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigOption;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigSide;
+
+import java.util.Locale;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
@@ -102,5 +104,9 @@ public abstract class AbstractDragonBody implements NBTInterface, Comparable<Abs
 
 	public Double getGravityMult() {
 		return 1.0;
+	}
+
+	public String getBodyNameLowerCase() {
+		return getBodyName().toLowerCase(Locale.ENGLISH);
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/AbstractDragonType.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/AbstractDragonType.java
@@ -4,6 +4,7 @@ import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler
 import by.dragonsurvivalteam.dragonsurvival.common.capability.NBTInterface;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.player.Player;
@@ -42,5 +43,17 @@ public abstract class AbstractDragonType implements NBTInterface, Comparable<Abs
 
 	public String getSubtypeName() {
 		return getTypeName();
+	}
+
+	public String getSubtypeNameLowerCase() {
+		return getTypeName().toLowerCase(Locale.ENGLISH);
+	}
+
+	public String getTypeNameUpperCase() {
+		return getTypeName().toUpperCase(Locale.ENGLISH);
+	}
+
+	public String getTypeNameLowerCase() {
+		return getTypeName().toLowerCase(Locale.ENGLISH);
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonBodies.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonBodies.java
@@ -7,6 +7,7 @@ import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.bodies.SouthBody
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.bodies.WestBodyType;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 public class DragonBodies {
@@ -30,18 +31,18 @@ public class DragonBodies {
 	
 	public static <T extends AbstractDragonBody> T registerType(Supplier<T> constructor) {
 		T body = constructor.get();
-		String lcName = body.getBodyName().toLowerCase();
+		String lcName = body.getBodyNameLowerCase();
 		bodyMappings.put(lcName, (Supplier<AbstractDragonBody>)constructor);
 		staticBodies.put(lcName, body);
 		return body;
 	}
 	
 	public static AbstractDragonBody getStatic(String name) {
-		return staticBodies.get(name.toLowerCase());
+		return staticBodies.get(name.toLowerCase(Locale.ENGLISH));
 	}
 
 	public static AbstractDragonBody newDragonBodyInstance(String name){
-		return bodyMappings.containsKey(name.toLowerCase()) ? bodyMappings.get(name.toLowerCase()).get() : null;
+		return bodyMappings.getOrDefault(name.toLowerCase(Locale.ENGLISH), () -> null).get();
 	}
 
 	public static List<String> getBodies() {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonTypes.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/dragon_types/DragonTypes.java
@@ -3,9 +3,12 @@ package by.dragonsurvivalteam.dragonsurvival.common.dragon_types;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.types.CaveDragonType;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.types.ForestDragonType;
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.types.SeaDragonType;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 public class DragonTypes {
@@ -26,7 +29,7 @@ public class DragonTypes {
 
 	public static <T extends AbstractDragonType> T registerType(Supplier<T> constructor){
 		T type = constructor.get();
-		String lcName = type.getTypeName().toLowerCase();
+		String lcName = type.getTypeNameLowerCase();
 		classMappings.put(lcName, (Supplier<AbstractDragonType>)constructor);
 		staticTypes.put(lcName, type);
 		staticSubtypes.put(lcName, type);
@@ -37,8 +40,8 @@ public class DragonTypes {
 	
 	public static <T extends AbstractDragonType> T registerSubtype(Supplier<T> constructor) {
 		T subtype = constructor.get();
-		String lcSubName = subtype.getSubtypeName().toLowerCase();
-		String lcTypeName = subtype.getTypeName().toLowerCase();
+		String lcSubName = subtype.getSubtypeNameLowerCase();
+		String lcTypeName = subtype.getTypeNameLowerCase();
 		classMappings.put(lcSubName, (Supplier<AbstractDragonType>) constructor);
 		
 		staticSubtypes.put(lcSubName, subtype);
@@ -48,11 +51,11 @@ public class DragonTypes {
 	}
 
 	public static AbstractDragonType getStatic(String name){
-		return staticTypes.get(name.toLowerCase());
+		return staticTypes.get(name.toLowerCase(Locale.ENGLISH));
 	}
 	
 	public static AbstractDragonType getStaticSubtype(String name) {
-		return staticSubtypes.get(name.toLowerCase());
+		return staticSubtypes.get(name.toLowerCase(Locale.ENGLISH));
 	}
 
 	public static List<String> getTypes(){
@@ -74,10 +77,10 @@ public class DragonTypes {
 	}
 	
 	public static List<AbstractDragonType> getSubtypesOfType(String name) {
-		return subtypeMap.getOrDefault(staticTypes.getOrDefault(name, null).getTypeName(), new ArrayList<AbstractDragonType>());
+		return subtypeMap.getOrDefault(staticTypes.getOrDefault(name, null).getTypeName(), new ArrayList<>());
 	}
 
-	public static AbstractDragonType newDragonTypeInstance(String name){
-		return classMappings.containsKey(name.toLowerCase()) ? classMappings.get(name.toLowerCase()).get() : null;
+	public static @Nullable AbstractDragonType newDragonTypeInstance(String name){
+		return classMappings.getOrDefault(name.toLowerCase(Locale.ENGLISH), () -> null).get();
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonTreatItem.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonTreatItem.java
@@ -42,6 +42,6 @@ public class DragonTreatItem extends Item {
 	@Override
 	public void appendHoverText(@NotNull ItemStack pStack, Item.@NotNull TooltipContext pContext, @NotNull List<Component> pTooltipComponents, @NotNull TooltipFlag pTooltipFlag) {
 		super.appendHoverText(pStack, pContext, pTooltipComponents, pTooltipFlag);
-		pTooltipComponents.add(Component.translatable("ds.description." + type.getTypeName().toLowerCase() + "DragonTreat"));
+		pTooltipComponents.add(Component.translatable("ds.description." + type.getTypeNameLowerCase() + "DragonTreat"));
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/innate/DragonClawsAbility.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/magic/common/innate/DragonClawsAbility.java
@@ -6,6 +6,7 @@ import by.dragonsurvivalteam.dragonsurvival.config.ServerConfig;
 import by.dragonsurvivalteam.dragonsurvival.util.DragonLevel;
 import com.mojang.datafixers.util.Pair;
 import java.util.ArrayList;
+import java.util.Locale;
 import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
@@ -37,7 +38,7 @@ public abstract class DragonClawsAbility extends InnateDragonAbility {
 		Pair<Tiers, Integer> harvestInfo = getHarvestInfo();
 
 		if (harvestInfo != null) {
-			components.add(Component.translatable("ds.skill.harvest_level", I18n.get("ds.skill.harvest_level." + harvestInfo.getFirst().name().toLowerCase())));
+			components.add(Component.translatable("ds.skill.harvest_level", I18n.get("ds.skill.harvest_level." + harvestInfo.getFirst().name().toLowerCase(Locale.ENGLISH))));
 		}
 
 		double damageBonus = handler.isDragon() && ServerConfig.attackDamage ? handler.getLevel() == DragonLevel.ADULT ? ServerConfig.adultBonusDamage : handler.getLevel() == DragonLevel.YOUNG ? ServerConfig.youngBonusDamage : ServerConfig.babyBonusDamage : 0;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/ApplyMixinPlugin.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/ApplyMixinPlugin.java
@@ -1,24 +1,41 @@
 package by.dragonsurvivalteam.dragonsurvival.mixins;
 
-import java.util.List;
-import java.util.Set;
+import net.neoforged.fml.loading.LoadingModList;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
+import java.util.List;
+import java.util.Set;
+
 public class ApplyMixinPlugin implements IMixinConfigPlugin {
+    private final static String PREFIX = ApplyMixinPlugin.class.getPackageName() + ".";
+
     @Override
     public void onLoad(final String mixinPackage) { /* Nothing to do */ }
 
     @Override
     public String getRefMapperConfig() {
-        /* Nothing to do */
         return null;
     }
 
     @Override
     public boolean shouldApplyMixin(final String targetClassName, final String mixinClassName) {
-        // `ModList.get()` is not available at this point in time
+        String modid = mixinClassName.replace(PREFIX, "");
+        // Remove directories which are not related to mods
+        modid = modid.replace("client.", "");
+        modid = modid.replace("tool_swap.", "");
+        // If a directory is still present it will run through the check below
+        String[] elements = modid.split("\\.");
+
+        if (elements.length == 2) {
+            return LoadingModList.get().getModFileById(elements[0]) != null;
+        }
+
+        if (mixinClassName.equals("by.dragonsurvivalteam.dragonsurvival.mixins.client.LiquidBlockRendererMixin")) {
+            return LoadingModList.get().getModFileById("embeddium") == null;
+        }
+
         return true;
     }
 
@@ -27,7 +44,6 @@ public class ApplyMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins() {
-        /* Nothing to do */
         return null;
     }
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/embeddium/ClientNeoForgeModMixin.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/embeddium/ClientNeoForgeModMixin.java
@@ -1,7 +1,7 @@
 package by.dragonsurvivalteam.dragonsurvival.mixins.embeddium;
 
 import by.dragonsurvivalteam.dragonsurvival.client.render.VisionHandler;
-import by.dragonsurvivalteam.dragonsurvival.client.util.ClientFluidTypeExtensionsProxy;
+import by.dragonsurvivalteam.dragonsurvival.client.util.ClientFluidTypeExtensionsWrapper;
 import net.neoforged.neoforge.client.ClientNeoForgeMod;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,11 +13,11 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public abstract class ClientNeoForgeModMixin {
     @ModifyArg(method = "onRegisterClientExtensions", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent;registerFluidType(Lnet/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions;[Lnet/neoforged/neoforge/fluids/FluidType;)V", ordinal = 0))
     private static IClientFluidTypeExtensions dragonSurvival$modifyWater(final IClientFluidTypeExtensions original) {
-        return new ClientFluidTypeExtensionsProxy(original, VisionHandler.VisionType.WATER);
+        return new ClientFluidTypeExtensionsWrapper(original, VisionHandler.VisionType.WATER);
     }
 
     @ModifyArg(method = "onRegisterClientExtensions", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent;registerFluidType(Lnet/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions;[Lnet/neoforged/neoforge/fluids/FluidType;)V", ordinal = 1))
     private static IClientFluidTypeExtensions dragonSurvival$modifyLava(final IClientFluidTypeExtensions original) {
-        return new ClientFluidTypeExtensionsProxy(original, VisionHandler.VisionType.LAVA);
+        return new ClientFluidTypeExtensionsWrapper(original, VisionHandler.VisionType.LAVA);
     }
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/embeddium/ClientNeoForgeModMixin.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/mixins/embeddium/ClientNeoForgeModMixin.java
@@ -1,0 +1,23 @@
+package by.dragonsurvivalteam.dragonsurvival.mixins.embeddium;
+
+import by.dragonsurvivalteam.dragonsurvival.client.render.VisionHandler;
+import by.dragonsurvivalteam.dragonsurvival.client.util.ClientFluidTypeExtensionsProxy;
+import net.neoforged.neoforge.client.ClientNeoForgeMod;
+import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(ClientNeoForgeMod.class)
+@SuppressWarnings("UnstableApiUsage")
+public abstract class ClientNeoForgeModMixin {
+    @ModifyArg(method = "onRegisterClientExtensions", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent;registerFluidType(Lnet/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions;[Lnet/neoforged/neoforge/fluids/FluidType;)V", ordinal = 0))
+    private static IClientFluidTypeExtensions dragonSurvival$modifyWater(final IClientFluidTypeExtensions original) {
+        return new ClientFluidTypeExtensionsProxy(original, VisionHandler.VisionType.WATER);
+    }
+
+    @ModifyArg(method = "onRegisterClientExtensions", at = @At(value = "INVOKE", target = "Lnet/neoforged/neoforge/client/extensions/common/RegisterClientExtensionsEvent;registerFluidType(Lnet/neoforged/neoforge/client/extensions/common/IClientFluidTypeExtensions;[Lnet/neoforged/neoforge/fluids/FluidType;)V", ordinal = 1))
+    private static IClientFluidTypeExtensions dragonSurvival$modifyLava(final IClientFluidTypeExtensions original) {
+        return new ClientFluidTypeExtensionsProxy(original, VisionHandler.VisionType.LAVA);
+    }
+}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
@@ -112,8 +112,8 @@ public class ClientProxy {
             if(DragonEditorRegistry.getSavedCustomizations() != null){
                 AbstractDragonType type = cap.getType();
                 if(type != null) {
-                    int currentSelected = DragonEditorRegistry.getSavedCustomizations().current.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(cap.getLevel(), 0);
-                    SkinPreset preset = DragonEditorRegistry.getSavedCustomizations().skinPresets.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(currentSelected, new SkinPreset());
+                    int currentSelected = DragonEditorRegistry.getSavedCustomizations().current.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(cap.getLevel(), 0);
+                    SkinPreset preset = DragonEditorRegistry.getSavedCustomizations().skinPresets.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(currentSelected, new SkinPreset());
                     PacketDistributor.sendToServer(new SyncPlayerSkinPreset.Data(localPlayer.getId(), preset.serializeNBT(localPlayer.registryAccess())));
                 }
             } else {
@@ -133,8 +133,8 @@ public class ClientProxy {
             if(DragonEditorRegistry.getSavedCustomizations() != null){
                 AbstractDragonType type = cap.getType();
                 if(type != null) {
-                    int currentSelected = DragonEditorRegistry.getSavedCustomizations().current.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(cap.getLevel(), 0);
-                    SkinPreset preset = DragonEditorRegistry.getSavedCustomizations().skinPresets.getOrDefault(type.getTypeName().toUpperCase(), new HashMap<>()).getOrDefault(currentSelected, new SkinPreset());
+                    int currentSelected = DragonEditorRegistry.getSavedCustomizations().current.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(cap.getLevel(), 0);
+                    SkinPreset preset = DragonEditorRegistry.getSavedCustomizations().skinPresets.getOrDefault(type.getTypeNameUpperCase(), new HashMap<>()).getOrDefault(currentSelected, new SkinPreset());
                     context.reply(new SyncPlayerSkinPreset.Data(sender.getId(), preset.serializeNBT(sender.registryAccess())));
                 }
             } else {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/datagen/DataBlockStateProvider.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/datagen/DataBlockStateProvider.java
@@ -19,6 +19,8 @@ import net.neoforged.neoforge.client.model.generators.ModelFile;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Locale;
+
 public class DataBlockStateProvider extends BlockStateProvider {
 	public DataBlockStateProvider(final PackOutput output, final String modId, final ExistingFileHelper existingFileHelper) {
 		super(output, modId, existingFileHelper);
@@ -149,7 +151,7 @@ public class DataBlockStateProvider extends BlockStateProvider {
 									int yRot = (int) state.getValue(BlockStateProperties.HORIZONTAL_FACING).toYRot();
 									// Map model file based off of the current state
 									VaultState vaultState = state.getValue(VaultBlock.STATE);
-									String suffix = vaultState.name().toLowerCase();
+									String suffix = vaultState.name().toLowerCase(Locale.ENGLISH);
 									// For some reason, vanilla named this state "ejecting_reward" instead of just "ejecting", so I'm maintaining that convention here
 									if(vaultState == VaultState.EJECTING) {
 										suffix = "ejecting_reward";

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonLevel.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/util/DragonLevel.java
@@ -4,6 +4,8 @@ package by.dragonsurvivalteam.dragonsurvival.util;
 import com.google.gson.annotations.SerializedName;
 import net.minecraft.client.resources.language.I18n;
 
+import java.util.Locale;
+
 public enum DragonLevel{
 	@SerializedName(value = "NEWBORN", alternate = "BABY")
 	NEWBORN(14, 1.1f, "newborn"),
@@ -22,5 +24,9 @@ public enum DragonLevel{
 
 	public String getName(){
 		return I18n.get("ds.level." + name);
+	}
+
+	public String getNameLowerCase() {
+		return getName().toLowerCase(Locale.ENGLISH);
 	}
 }

--- a/src/main/resources/dragonsurvival.mixins.json
+++ b/src/main/resources/dragonsurvival.mixins.json
@@ -3,6 +3,7 @@
   "package": "by.dragonsurvivalteam.dragonsurvival.mixins",
   "compatibilityLevel": "JAVA_21",
   "minVersion": "0.8",
+  "plugin": "by.dragonsurvivalteam.dragonsurvival.mixins.ApplyMixinPlugin",
   "refmap": "dragonsurvival.refmap.json",
   "mixins": [
     "AccessorAnimationController",
@@ -38,6 +39,7 @@
     "client.LightTextureMixin",
     "client.LiquidBlockRendererMixin",
     "client.LocalPlayerMixin",
+    "embeddium.ClientNeoForgeModMixin",
     "tool_swap.MixinMultiPlayerGameModeEnd",
     "tool_swap.MixinMultiPlayerGameModeStart"
   ]


### PR DESCRIPTION
+ added embeddium compat regarding the vision handler
+ increased visibility range in lava for lava vision
+ fixed the scroll bar for the part selection
+ added the locale change (to use english for the parts etc.)
+ use default logic for parchment (https://github.com/DragonSurvivalTeam/DragonSurvival/pull/631/commits/89852f63ee73d3c1f0ce8cee86e4b4f3d7ae5677)

also this change here:
https://github.com/DragonSurvivalTeam/DragonSurvival/blob/8c726d7c071327e6a6beaaffcc19afee7937f2c5/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorHandler.java#L208-L215

Saw this by the way:
```
[10:01:36] [Worker-Main-11/ERROR] [minecraft/TagLoader]: Couldn't load tag dragonsurvival:underground_avoid as it is missing following references: 
	minecraft:trial_chamber (from mod/dragonsurvival)
	#minecraft:on_trial_chambers_maps (from mod/dragonsurvival)
[10:01:36] [Worker-Main-11/ERROR] [minecraft/TagLoader]: Couldn't load tag dragonsurvival:all_friendly_treasure as it is missing following references: 
	dragonsurvival:treasure_friendly_cave (from mod/dragonsurvival)
	dragonsurvival:treasure_friendly_forest (from mod/dragonsurvival)
	dragonsurvival:treasure_friendly_sea (from mod/dragonsurvival)
[10:01:36] [Worker-Main-9/ERROR] [minecraft/TagLoader]: Couldn't load tag dragonsurvival:dragon_vault_keys as it is missing following references: 
	dragonsurvival:good_dragon_key (from mod/dragonsurvival)
	dragonsurvival:evil_dragon_key (from mod/dragonsurvival)
```