### PR TITLE
Made skin loading asynchronous to prevent stalls

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/SkinsScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/SkinsScreen.java
@@ -121,10 +121,10 @@ public class SkinsScreen extends Screen{
 		EntityRenderer<? super DragonEntity> dragonRenderer = Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(dragon);
 
 		if(noSkin && Objects.equals(playerName, minecraft.player.getGameProfile().getName())){
-			ClientDragonRenderer.dragonModel.setCurrentTexture(null);
+			ClientDragonRenderer.dragonModel.setOverrideTexture(null);
 			((DragonRenderer)dragonRenderer).glowTexture = null;
 		}else{
-			ClientDragonRenderer.dragonModel.setCurrentTexture(skinTexture);
+			ClientDragonRenderer.dragonModel.setOverrideTexture(skinTexture);
 			((DragonRenderer)dragonRenderer).glowTexture = glowTexture;
 		}
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -593,9 +593,6 @@ public class DragonEditorScreen extends Screen {
 			HANDLER.setType(dragonType);
 		}
 
-		// Do this so the body type actually refreshes when the dragon type changes
-		FakeClientPlayerUtils.forceRefreshFirstFakePlayer();
-
 		HANDLER.setBody(dragonBody);
 		HANDLER.getSkinData().skinPreset = preset;
 		HANDLER.setSize(level.size);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
@@ -6,6 +6,7 @@ import by.dragonsurvivalteam.dragonsurvival.client.render.ClientDragonRenderer;
 import by.dragonsurvivalteam.dragonsurvival.client.skin_editor_system.DragonEditorHandler;
 import by.dragonsurvivalteam.dragonsurvival.client.skin_editor_system.objects.SkinPreset.SkinAgeGroup;
 import by.dragonsurvivalteam.dragonsurvival.client.util.FakeClientPlayer;
+import by.dragonsurvivalteam.dragonsurvival.client.util.RenderingUtils;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.objects.DragonMovementData;
@@ -141,7 +142,7 @@ public class DragonModel extends GeoModel<DragonEntity> {
 					handler.getSkinData().isCompiled = true;
 					handler.getSkinData().recompileSkin = false;
 					for(Pair<NativeImage, ResourceLocation> pair : imageGenerationFuture.join()){
-						DragonEditorHandler.registerCompiledTexture(pair.getFirst(), pair.getSecond());
+						RenderingUtils.uploadTexture(pair.getFirst(), pair.getSecond());
 					}
 				}, Minecraft.getInstance());
 			}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/models/DragonModel.java
@@ -12,6 +12,8 @@ import by.dragonsurvivalteam.dragonsurvival.common.capability.objects.DragonMove
 import by.dragonsurvivalteam.dragonsurvival.common.dragon_types.AbstractDragonBody;
 import by.dragonsurvivalteam.dragonsurvival.common.entity.DragonEntity;
 import by.dragonsurvivalteam.dragonsurvival.util.Functions;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.RenderType;
@@ -22,10 +24,14 @@ import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.loading.math.MathParser;
 import software.bernie.geckolib.model.GeoModel;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 public class DragonModel extends GeoModel<DragonEntity> {
 	private final ResourceLocation defaultTexture = ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/cave_newborn.png");
 	private final ResourceLocation model = ResourceLocation.fromNamespaceAndPath(MODID, "geo/dragon_model.geo.json");
-	private ResourceLocation currentTexture;
+	private ResourceLocation overrideTexture;
+	private CompletableFuture<Void> textureRegisterFuture = CompletableFuture.completedFuture(null);
 
 	/**TODO Body Types Update
 	Required:
@@ -114,31 +120,38 @@ public class DragonModel extends GeoModel<DragonEntity> {
 
 	public ResourceLocation getTextureResource(final DragonEntity dragon) {
 		if (dragon.playerId != null || dragon.getPlayer() != null) {
+			if(overrideTexture != null) {
+				return overrideTexture;
+			}
+
 			DragonStateHandler handler = DragonStateProvider.getOrGenerateHandler(dragon.getPlayer());
 			SkinAgeGroup ageGroup = handler.getSkinData().skinPreset.skinAges.get(handler.getLevel()).get();
-
-			if (handler.getSkinData().recompileSkin) {
-				DragonEditorHandler.generateSkinTextures(dragon);
-			}
 
 			if (handler.getSkinData().blankSkin) {
 				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/blank_skin_" + handler.getTypeNameLowerCase() + ".png");
 			}
 
 			if (ageGroup.defaultSkin) {
-				if (currentTexture != null) {
-					return currentTexture;
-				}
-
 				return ResourceLocation.fromNamespaceAndPath(MODID, "textures/dragon/" + handler.getTypeNameLowerCase() + "_" + handler.getLevel().getNameLowerCase() + ".png");
 			}
 
-			if (handler.getSkinData().isCompiled && currentTexture == null) {
+			if (handler.getSkinData().recompileSkin && textureRegisterFuture.isDone()) {
+				CompletableFuture<List<Pair<NativeImage, ResourceLocation>>> imageGenerationFuture = DragonEditorHandler.generateSkinTextures(dragon);
+				textureRegisterFuture = imageGenerationFuture.thenRunAsync(() -> {
+					handler.getSkinData().isCompiled = true;
+					handler.getSkinData().recompileSkin = false;
+					for(Pair<NativeImage, ResourceLocation> pair : imageGenerationFuture.join()){
+						DragonEditorHandler.registerCompiledTexture(pair.getFirst(), pair.getSecond());
+					}
+				}, Minecraft.getInstance());
+			}
+
+			if (handler.getSkinData().isCompiled) {
 				return ResourceLocation.fromNamespaceAndPath(MODID, "dynamic_normal_" + dragon.getPlayer().getStringUUID() + "_" + handler.getLevel().name);
 			}
 		}
 
-		if (currentTexture == null && dragon.getPlayer() instanceof FakeClientPlayer) {
+		if (dragon.getPlayer() instanceof FakeClientPlayer) {
 			LocalPlayer localPlayer = Minecraft.getInstance().player;
 
 			if (localPlayer != null) { // TODO :: Check if skin is compiled?
@@ -146,11 +159,11 @@ public class DragonModel extends GeoModel<DragonEntity> {
 			}
 		}
 
-		return currentTexture == null ? defaultTexture : currentTexture;
+		return defaultTexture;
 	}
 
-	public void setCurrentTexture(final ResourceLocation currentTexture) {
-		this.currentTexture = currentTexture;
+	public void setOverrideTexture(final ResourceLocation overrideTexture) {
+		this.overrideTexture = overrideTexture;
 	}
 
 	@Override

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRenderer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/ClientDragonRenderer.java
@@ -255,7 +255,7 @@ public class ClientDragonRenderer {
 				((AccessorEntityRenderer) renderPlayerEvent.getRenderer()).setShadowRadius((float) ((3.0F * size + 62.0F) / 260.0F));
 				DragonEntity dummyDragon = playerDragonHashMap.get(player.getId()).get();
 				EntityRenderer<? super DragonEntity> dragonRenderer = minecraft.getEntityRenderDispatcher().getRenderer(dummyDragon);
-				dragonModel.setCurrentTexture(texture);
+				dragonModel.setOverrideTexture(texture);
 
 				if(player.isCrouching() && handler.isWingsSpread() && !player.onGround()){
 					poseStack.translate(0, -0.15, 0);
@@ -377,7 +377,7 @@ public class ClientDragonRenderer {
 				((AccessorEntityRenderer) renderPlayerEvent.getRenderer()).setShadowRadius(0.5F);
 			}
 		}
-		dragonModel.setCurrentTexture(null);
+		dragonModel.setOverrideTexture(null);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
@@ -3,7 +3,9 @@ package by.dragonsurvivalteam.dragonsurvival.client.render.entity.dragon;
 import static by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod.LOGGER;
 import static by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod.res;
 
+import by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod;
 import by.dragonsurvivalteam.dragonsurvival.client.render.ClientDragonRenderer;
+import by.dragonsurvivalteam.dragonsurvival.client.util.RenderingUtils;
 import by.dragonsurvivalteam.dragonsurvival.common.entity.DragonEntity;
 import by.dragonsurvivalteam.dragonsurvival.common.items.armor.EvilDragonArmorItem;
 import by.dragonsurvivalteam.dragonsurvival.common.items.armor.GoodDragonArmorItem;
@@ -17,6 +19,8 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -41,6 +45,7 @@ import software.bernie.geckolib.renderer.layer.GeoRenderLayer;
 public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
 	private final GeoEntityRenderer<DragonEntity> renderer;
 	private static final AbstractTexture missingno = Minecraft.getInstance().getTextureManager().getTexture(ResourceLocation.withDefaultNamespace("missingno"));
+	private static final HashMap<ResourceLocation, CompletableFuture<Void>> armorTextures = new HashMap<>();
 	private static final HashMap<EquipmentSlot, NativeImage> armorMasks = new HashMap<>();
 	private static final String armorTrimDir = "textures/armor/armor_trims/";
 
@@ -79,10 +84,12 @@ public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
 		}
 
 		if(hasAnyArmorEquipped(player)) {
-			ResourceLocation armorTexture = constructTrimmedDragonArmorTexture(player);
-			((DragonRenderer) renderer).isRenderLayers = true;
-			renderArmor(poseStack, animatable, bakedModel, bufferSource, partialTick, packedLight, armorTexture);
-			((DragonRenderer) renderer).isRenderLayers = false;
+			Optional<ResourceLocation> armorTexture = constructTrimmedDragonArmorTexture(player);
+			if(armorTexture.isPresent()) {
+				((DragonRenderer) renderer).isRenderLayers = true;
+				renderArmor(poseStack, animatable, bakedModel, bufferSource, partialTick, packedLight, armorTexture.get());
+				((DragonRenderer) renderer).isRenderLayers = false;
+			}
 		}
 	}
 
@@ -101,110 +108,128 @@ public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
 		}
 	}
 
-	private static ResourceLocation constructTrimmedDragonArmorTexture(final Player pPlayer) {
-		try (NativeImage image = new NativeImage(512, 512, true)) {
+	private static Optional<ResourceLocation> constructTrimmedDragonArmorTexture(final Player pPlayer) {
 			String armorUUID = buildUniqueArmorUUID(pPlayer);
 			ResourceLocation imageLoc = res("armor_" + armorUUID);
-			if (Minecraft.getInstance().getTextureManager().getTexture(imageLoc, missingno) instanceof DynamicTexture texture && !texture.equals(missingno)) {
-				return imageLoc;
-			}
-			for (EquipmentSlot slot : EquipmentSlot.values()) {
-				if (!armorMasks.containsKey(slot)) continue;
-				ItemStack itemstack = pPlayer.getItemBySlot(slot);
-				ResourceLocation existingArmorLocation = res(constructArmorTexture(pPlayer, slot));
-				if (itemstack.getItem() instanceof ArmorItem item) {
+			if(armorTextures.containsKey(imageLoc)) {
+				CompletableFuture<Void> future = armorTextures.get(imageLoc);
+				if (future.isDone()) {
 					try {
-						ArmorTrim trim = itemstack.get(DataComponents.TRIM);
-						Optional<Resource> armorFile = Minecraft.getInstance().getResourceManager().getResource(existingArmorLocation);
-						NativeImage armorImage, trimImage = null;
-						boolean trimOk = false;
+						return Optional.of(imageLoc);
+					} catch (Exception e) {
+						LOGGER.error(e);
+					}
+				}
+			} else {
+				CompletableFuture<NativeImage> imageCompilationStep = CompletableFuture.supplyAsync(() -> {
+					try {
+						return compileArmorTexture(pPlayer);
+					} catch (IOException e) {
+						DragonSurvivalMod.LOGGER.error("An error occurred while compiling the dragon armor texture", e);
+					}
 
-						Color trimBaseColor;
-						float[] trimBaseHSB = new float[3];
+					return new NativeImage(0, 0, true);
+				});
+				CompletableFuture<Void> uploadStep = imageCompilationStep.thenRunAsync(() -> {
+					try {
+						RenderingUtils.uploadTexture(imageCompilationStep.get(), imageLoc);
+					} catch (Exception e) {
+						LOGGER.error(e);
+					}
+				}, Minecraft.getInstance());
+				armorTextures.put(imageLoc, uploadStep);
+			}
 
-						if (armorFile.isPresent()) {
-							InputStream textureStream = armorFile.get().open();
-							armorImage = NativeImage.read(textureStream);
-							textureStream.close();
-						} else {
-							continue;
-						}
+			return Optional.empty();
+	}
 
-						if (trim != null) {
-							String patternPath = trim.pattern().value().assetId().getPath();
-							Optional<Resource> trimFile = Minecraft.getInstance().getResourceManager().getResource(res("textures/armor/armor_trims/" + patternPath + ".png"));
-
-							if (trimFile.isPresent()) {
-								InputStream textureStream = trimFile.get().open();
-								trimImage = NativeImage.read(textureStream);
-								textureStream.close();
-								trimOk = true;
-							}
-							TextColor tc = trim.material().value().description().getStyle().getColor();
-							if (tc != null) {
-								// Not the most elegant solution,
-								// but the best way I could find to get a single color reliably...
-								// TODO: something better
-								trimBaseColor = new Color(tc.getValue());
-								Color.RGBtoHSB(trimBaseColor.getBlue(), trimBaseColor.getGreen(), trimBaseColor.getRed(), trimBaseHSB);
-							}
-						}
-						float[] armorHSB = new float[3];
-						float[] trimHSB = new float[3];
-						float[] dyeHSB = new float[3];
-						DyedItemColor dyeColor = itemstack.get(DataComponents.DYED_COLOR);
-						if (dyeColor != null) {
-							Color armorDye = new Color(dyeColor.rgb());
-							Color.RGBtoHSB(armorDye.getBlue(), armorDye.getGreen(), armorDye.getRed(), dyeHSB);
-						}
-
-						for (int x = 0; x < armorImage.getWidth(); x++) {
-							for (int y = 0; y < armorImage.getHeight(); y++) {
-								if (armorMasks.get(slot).getPixelRGBA(x, y) == 0) continue;
-								Color armorColor = new Color(armorImage.getPixelRGBA(x, y), true);
-								if (trimOk) {
-									Color trimColor = new Color(trimImage.getPixelRGBA(x, y), true);
-									Color.RGBtoHSB(trimColor.getRed(), trimColor.getGreen(), trimColor.getBlue(), trimHSB);
-									if (trimColor.getAlpha() != 0) {
-										// Changes the hue and saturation to be the same as the trim's base color while keeping the design's brightness
-										if (trimHSB[1] == 0) {
-											// Replace any grayscale parts with the appropriate trim color
-											image.setPixelRGBA(x, y, Color.HSBtoRGB(trimBaseHSB[0], trimBaseHSB[1], trimHSB[2]));
-										}/* else {
-											// Otherwise, keep the same color (for parts that should not change color)
-											image.setPixelRGBA(x, y, trimColor.getRGB());
-										}*/
-									} else if (armorColor.getAlpha() != 0) {
-										// There is no trim on this pixel and we can ignore it safely
-										if (dyeHSB[0] != 0 && dyeHSB[1] != 0) {
-											// Get the armor's brightness, and the dye's hue and saturation
-											image.setPixelRGBA(x, y, Color.HSBtoRGB(dyeHSB[0], dyeHSB[1], Color.RGBtoHSB(armorColor.getRed(), armorColor.getGreen(), armorColor.getBlue(), null)[1]));
-										} else {
-											image.setPixelRGBA(x, y, armorColor.getRGB());
-										}
-									}
-								} else if (armorColor.getAlpha() != 0){
-									// No armor trim, just the armor
-									Color.RGBtoHSB(armorColor.getRed(), armorColor.getGreen(), armorColor.getBlue(), armorHSB);
-									if ((dyeHSB[0] != 0 || dyeHSB[1] != 0) && armorHSB[1] == 0) {
-										// Get the armor's brightness, and the dye's hue and saturation
-										image.setPixelRGBA(x, y, Color.HSBtoRGB(dyeHSB[0], dyeHSB[1], armorHSB[2]));
-									} else {
-										image.setPixelRGBA(x, y, armorColor.getRGB());
-									}
+	private static NativeImage compileArmorTexture(final Player pPlayer) throws IOException {
+		NativeImage image = new NativeImage(512, 512, true);
+		for (EquipmentSlot slot : EquipmentSlot.values()) {
+			if (!armorMasks.containsKey(slot)) continue;
+			ItemStack itemstack = pPlayer.getItemBySlot(slot);
+			ResourceLocation existingArmorLocation = res(constructArmorTexture(pPlayer, slot));
+			if (itemstack.getItem() instanceof ArmorItem) {
+				ArmorTrim trim = itemstack.get(DataComponents.TRIM);
+				Optional<Resource> armorFile = Minecraft.getInstance().getResourceManager().getResource(existingArmorLocation);
+				NativeImage armorImage, trimImage = null;
+				boolean trimOk = false;
+				Color trimBaseColor;
+				float[] trimBaseHSB = new float[3];
+				if (armorFile.isPresent()) {
+					InputStream textureStream = armorFile.get().open();
+					armorImage = NativeImage.read(textureStream);
+					textureStream.close();
+				} else {
+					continue;
+				}
+				if (trim != null) {
+					String patternPath = trim.pattern().value().assetId().getPath();
+					Optional<Resource> trimFile = Minecraft.getInstance().getResourceManager().getResource(res("textures/armor/armor_trims/" + patternPath + ".png"));
+					if (trimFile.isPresent()) {
+						InputStream textureStream = trimFile.get().open();
+						trimImage = NativeImage.read(textureStream);
+						textureStream.close();
+						trimOk = true;
+					}
+					TextColor tc = trim.material().value().description().getStyle().getColor();
+					if (tc != null) {
+						// Not the most elegant solution,
+						// but the best way I could find to get a single color reliably...
+						// TODO: something better
+						trimBaseColor = new Color(tc.getValue());
+						Color.RGBtoHSB(trimBaseColor.getBlue(), trimBaseColor.getGreen(), trimBaseColor.getRed(), trimBaseHSB);
+					}
+				}
+				float[] armorHSB = new float[3];
+				float[] trimHSB = new float[3];
+				float[] dyeHSB = new float[3];
+				DyedItemColor dyeColor = itemstack.get(DataComponents.DYED_COLOR);
+				if (dyeColor != null) {
+					Color armorDye = new Color(dyeColor.rgb());
+					Color.RGBtoHSB(armorDye.getBlue(), armorDye.getGreen(), armorDye.getRed(), dyeHSB);
+				}
+				for (int x = 0; x < armorImage.getWidth(); x++) {
+					for (int y = 0; y < armorImage.getHeight(); y++) {
+						if (armorMasks.get(slot).getPixelRGBA(x, y) == 0) continue;
+						Color armorColor = new Color(armorImage.getPixelRGBA(x, y), true);
+						if (trimOk) {
+							Color trimColor = new Color(trimImage.getPixelRGBA(x, y), true);
+							Color.RGBtoHSB(trimColor.getRed(), trimColor.getGreen(), trimColor.getBlue(), trimHSB);
+							if (trimColor.getAlpha() != 0) {
+								// Changes the hue and saturation to be the same as the trim's base color while keeping the design's brightness
+								if (trimHSB[1] == 0) {
+									// Replace any grayscale parts with the appropriate trim color
+									image.setPixelRGBA(x, y, Color.HSBtoRGB(trimBaseHSB[0], trimBaseHSB[1], trimHSB[2]));
+								}/* else {
+										// Otherwise, keep the same color (for parts that should not change color)
+										image.setPixelRGBA(x, y, trimColor.getRGB());
+									}*/
+							} else if (armorColor.getAlpha() != 0) {
+								// There is no trim on this pixel and we can ignore it safely
+								if (dyeHSB[0] != 0 && dyeHSB[1] != 0) {
+									// Get the armor's brightness, and the dye's hue and saturation
+									image.setPixelRGBA(x, y, Color.HSBtoRGB(dyeHSB[0], dyeHSB[1], Color.RGBtoHSB(armorColor.getRed(), armorColor.getGreen(), armorColor.getBlue(), null)[1]));
+								} else {
+									image.setPixelRGBA(x, y, armorColor.getRGB());
 								}
 							}
+						} else if (armorColor.getAlpha() != 0){
+							// No armor trim, just the armor
+							Color.RGBtoHSB(armorColor.getRed(), armorColor.getGreen(), armorColor.getBlue(), armorHSB);
+							if ((dyeHSB[0] != 0 || dyeHSB[1] != 0) && armorHSB[1] == 0) {
+								// Get the armor's brightness, and the dye's hue and saturation
+								image.setPixelRGBA(x, y, Color.HSBtoRGB(dyeHSB[0], dyeHSB[1], armorHSB[2]));
+							} else {
+								image.setPixelRGBA(x, y, armorColor.getRGB());
+							}
 						}
-					} catch (IOException e) {
-						LOGGER.error("An error occurred while compiling the dragon armor trim texture", e);
 					}
 				}
 			}
-			uploadTexture(image, imageLoc);
-			image.close();
-			return imageLoc;
 		}
-	}
+        return image;
+    }
 
 	private static boolean hasAnyArmorEquipped(Player pPlayer) {
 		for (EquipmentSlot slot : EquipmentSlot.values()) {
@@ -239,25 +264,6 @@ public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
 			}
 		}
 		return UUID.nameUUIDFromBytes(armorTotal.toString().getBytes()).toString();
-	}
-
-	private static void uploadTexture(NativeImage image, ResourceLocation location) {
-		try (image) {
-			if (Minecraft.getInstance().getTextureManager().getTexture(location, missingno) instanceof DynamicTexture texture && !texture.equals(missingno)) {
-				texture.setPixels(image);
-				texture.upload();
-            } else {
-				DynamicTexture layer = new DynamicTexture(image);
-				Minecraft.getInstance().getTextureManager().register(location, layer);
-            }
-            /*File file = new File(Minecraft.getInstance().gameDirectory, "texture");
-			file.mkdirs();
-			file = new File(file.getPath(), armorTrimKey.toString().replace(":", "_") + ".png");
-			file.getParentFile().mkdirs();
-			image.writeToFile(file);*/
-		} catch (Exception e) {
-			LOGGER.error(e);
-		}
 	}
 
 	private static String constructArmorTexture(Player playerEntity, EquipmentSlot equipmentSlot){

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
@@ -3,7 +3,6 @@ package by.dragonsurvivalteam.dragonsurvival.client.render.entity.dragon;
 import static by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod.LOGGER;
 import static by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod.res;
 
-import by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod;
 import by.dragonsurvivalteam.dragonsurvival.client.render.ClientDragonRenderer;
 import by.dragonsurvivalteam.dragonsurvival.common.entity.DragonEntity;
 import by.dragonsurvivalteam.dragonsurvival.common.items.armor.EvilDragonArmorItem;
@@ -94,7 +93,7 @@ public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
 
 		Color armorColor = new Color(1f, 1f, 1f);
 
-		ClientDragonRenderer.dragonModel.setCurrentTexture(texture);
+		ClientDragonRenderer.dragonModel.setOverrideTexture(texture);
 		RenderType type = renderer.getRenderType(animatable, texture, bufferSource, partialTick);
 		if (type != null) {
 			VertexConsumer vertexConsumer = bufferSource.getBuffer(type);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skin_editor_system/DragonEditorHandler.java
@@ -114,7 +114,7 @@ public class DragonEditorHandler{
 			try {
 				return genTextures(player, handler, skinAgeGroupsAndDragonLevels);
 			} catch (Throwable e) {
-				DragonSurvivalMod.LOGGER.error("An error occured while compiling the dragon skin texture", e);
+				DragonSurvivalMod.LOGGER.error("An error occurred while compiling the dragon skin texture", e);
 			}
 
 			return new ArrayList<>();
@@ -206,28 +206,5 @@ public class DragonEditorHandler{
 
 		Color c = new Color(Color.HSBtoRGB(hsb[0], hsb[1], hsb[2]));
 		return new Color(c.getRed(), c.getGreen(), c.getBlue(), color.getAlpha());
-	}
-
-	public static void registerCompiledTexture(NativeImage image, ResourceLocation key){
-		try (image) {
-			// DEBUG :: Export the texture
-			//if (key.toString().contains("dynamic_normal")) {
-			//	File file = new File(Minecraft.getInstance().gameDirectory, "texture");
-			//	file.mkdirs();
-			//	file = new File(file.getPath(), key.toString().replace(":", "_") + ".png");
-			//	image.writeToFile(file);
-			//}
-
-			// the other 'getTexture' call tries to register the texture immediately
-			if (Minecraft.getInstance().getTextureManager().getTexture(key, null) instanceof DynamicTexture texture) {
-				texture.setPixels(image);
-				texture.upload();
-			} else {
-				DynamicTexture layer = new DynamicTexture(image);
-				Minecraft.getInstance().getTextureManager().register(key, layer);
-			}
-		} catch (Exception e) {
-			DragonSurvivalMod.LOGGER.error(e);
-		}
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/FakeClientPlayerUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/FakeClientPlayerUtils.java
@@ -22,7 +22,6 @@ import software.bernie.geckolib.animation.RawAnimation;
 public class FakeClientPlayerUtils {
 	private static final ConcurrentHashMap<Integer, FakeClientPlayer> FAKE_PLAYERS = new ConcurrentHashMap<>();
 	private static final ConcurrentHashMap<Integer, DragonEntity> FAKE_DRAGONS = new ConcurrentHashMap<>();
-	private static boolean FORCE_REFRESH = false;
 
 	public static DragonEntity getFakeDragon(int index, final DragonStateHandler handler) {
 		FakeClientPlayer fakePlayer = getFakePlayer(index, handler);
@@ -31,10 +30,9 @@ public class FakeClientPlayerUtils {
 			@Override
 			public void registerControllers(final AnimatableManager.ControllerRegistrar controllers) {
 				AnimationController<DragonEntity> controller = new AnimationController<>(this, "fake_player_controller", 2, state -> {
-					if (fakePlayer.handler.refreshBody || FORCE_REFRESH) {
+					if (fakePlayer.handler.refreshBody) {
 						fakePlayer.animationController.forceAnimationReset();
 						fakePlayer.handler.refreshBody = false;
-                        FORCE_REFRESH = false;
 					}
 
 					if (fakePlayer.animationSupplier != null) {
@@ -77,9 +75,5 @@ public class FakeClientPlayerUtils {
 				FAKE_PLAYERS.remove(index);
 			}
 		});
-	}
-
-	public static void forceRefreshFirstFakePlayer(){
-		FORCE_REFRESH = true;
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/RenderingUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/util/RenderingUtils.java
@@ -1,15 +1,23 @@
 package by.dragonsurvivalteam.dragonsurvival.client.util;
 
+import by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod;
 import com.mojang.blaze3d.platform.GlStateManager.DestFactor;
 import com.mojang.blaze3d.platform.GlStateManager.SourceFactor;
+import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import java.awt.*;
+
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Matrix4f;
 import org.lwjgl.opengl.GL11;
+
+import static by.dragonsurvivalteam.dragonsurvival.DragonSurvivalMod.LOGGER;
 
 public class RenderingUtils{
 	static final double PI_TWO = Math.PI * 2.0;
@@ -255,5 +263,29 @@ public class RenderingUtils{
 		BufferUploader.drawWithShader(buffer.buildOrThrow());
 		GL11.glDisable(GL11.GL_LINE_SMOOTH);
 		RenderSystem.disableBlend();
+	}
+
+	public static void uploadTexture(NativeImage image, ResourceLocation key){
+		try (image) {
+			// DEBUG :: Export the texture
+			//if (key.toString().contains("dynamic_normal")) {
+			//	File file = new File(Minecraft.getInstance().gameDirectory, "texture");
+			//	file.mkdirs();
+			//	file = new File(file.getPath(), key.toString().replace(":", "_") + ".png");
+			//	image.writeToFile(file);
+			//}
+
+			// the other 'getTexture' call tries to register the texture immediately
+			if (Minecraft.getInstance().getTextureManager().getTexture(key, null) instanceof DynamicTexture texture) {
+				texture.setPixels(image);
+				texture.upload();
+            } else {
+				DynamicTexture layer = new DynamicTexture(image);
+				Minecraft.getInstance().getTextureManager().register(key, layer);
+				image.close();
+			}
+		} catch (Exception e) {
+			DragonSurvivalMod.LOGGER.error(e);
+		}
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -232,7 +232,7 @@ public class DragonStateHandler extends EntityStateHandler {
 	// Only call this version of setBody if we are doing something purely for rendering. Otherwise, call the setSize that accepts a Player object so that the player's attributes are updated.
 	public void setBody(final AbstractDragonBody body) {
 		if (body != null) {
-			if (!body.equals(dragonBody)) {
+			if (dragonBody == null || !body.getBodyName().equals(dragonBody.getBodyName())) {
 				dragonBody = DragonBodies.newDragonBodyInstance(body.getBodyName());
 				refreshBody = true;
 			}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/subcapabilities/SkinCap.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/subcapabilities/SkinCap.java
@@ -19,7 +19,6 @@ public class SkinCap extends SubCap{
 
 	public void compileSkin() {
 		recompileSkin = true;
-		isCompiled = false;
 	}
 
 	public SkinCap(DragonStateHandler handler){


### PR DESCRIPTION
Skin generation will now happen on a separate thread. This fixes a lot of issues, such as stalls when loading in initially, or in the dragon editor, or when equipping armor. If armor is being equipped and the skin isn't ready yet, no armor will be shown. If a player skin is trying to be loaded and nothing is ready yet, it will load the previous player skin (if available) or the default skin as a fallback.