### PR TITLE
Added in redo/undo functionality

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -63,6 +63,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.item.DyeColor;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ScreenEvent;
@@ -73,7 +75,7 @@ import org.apache.commons.lang3.text.WordUtils;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME)
+@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
 public class DragonEditorScreen extends Screen {
 	private static final ResourceLocation backgroundTexture = ResourceLocation.withDefaultNamespace("textures/block/black_concrete.png");
 	private static final ResourceLocation SAVE = ResourceLocation.fromNamespaceAndPath(MODID, "textures/gui/save_icon.png");

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -63,12 +63,17 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.item.DyeColor;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.neoforged.neoforge.client.gui.widget.ExtendedButton;
 import net.neoforged.neoforge.common.util.Lazy;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.apache.commons.lang3.text.WordUtils;
 import org.jetbrains.annotations.NotNull;
+import org.lwjgl.glfw.GLFW;
 
+@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME)
 public class DragonEditorScreen extends Screen {
 	private static final ResourceLocation backgroundTexture = ResourceLocation.withDefaultNamespace("textures/block/black_concrete.png");
 	private static final ResourceLocation SAVE = ResourceLocation.fromNamespaceAndPath(MODID, "textures/gui/save_icon.png");
@@ -855,5 +860,16 @@ public class DragonEditorScreen extends Screen {
 
 	public static String partToTechnical(final String part) {
 		return part.replace("ds.skin_part.", "").replace(DragonEditorScreen.HANDLER.getTypeNameLowerCase() + ".", "");
+	}
+
+	@SubscribeEvent
+	public static void undoRedoKeybinds(ScreenEvent.KeyPressed.Post event) {
+		if (event.getScreen() instanceof DragonEditorScreen screen) {
+			if (event.getKeyCode() == GLFW.GLFW_KEY_Z && event.getModifiers() == GLFW.GLFW_MOD_CONTROL) {
+				screen.actionHistory.undo();
+			} else if (event.getKeyCode() == GLFW.GLFW_KEY_Y && event.getModifiers() == GLFW.GLFW_MOD_CONTROL) {
+				screen.actionHistory.redo();
+			}
+		}
 	}
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/AdultEditorButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/AdultEditorButton.java
@@ -14,10 +14,7 @@ public class AdultEditorButton extends Button{
 
 	public AdultEditorButton(DragonEditorScreen dragonEditorScreen){
 		super(dragonEditorScreen.width / 2 + 60, dragonEditorScreen.guiTop - 30, 120, 20, Component.translatable("ds.level.adult"), btn -> {
-			dragonEditorScreen.level = DragonLevel.ADULT;
-			dragonEditorScreen.dragonRender.zoom = dragonEditorScreen.level.size * 2;
-			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-			dragonEditorScreen.update();
+			dragonEditorScreen.actionHistory.add(new DragonEditorScreen.EditorAction<>(dragonEditorScreen.selectLevelAction, DragonLevel.ADULT));
 		}, DEFAULT_NARRATION);
 		this.dragonEditorScreen = dragonEditorScreen;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonBodyButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonBodyButton.java
@@ -22,8 +22,7 @@ public class DragonBodyButton extends Button {
 	public DragonBodyButton(DragonEditorScreen dragonEditorScreen, int x, int y, int xSize, int ySize, AbstractDragonBody dragonBody, int pos, boolean locked) {
 		super(x, y, xSize, ySize, Component.literal(dragonBody.toString()), btn -> {
 			if (!locked) {
-				dragonEditorScreen.dragonBody = dragonBody;
-				dragonEditorScreen.update();
+				dragonEditorScreen.actionHistory.add(new DragonEditorScreen.EditorAction<>(dragonEditorScreen.dragonBodySelectAction, dragonBody));
 			}
 		}, DEFAULT_NARRATION);
 		location = ResourceLocation.fromNamespaceAndPath(MODID, "textures/gui/body_type_icon_" + dragonEditorScreen.dragonType.getTypeNameLowerCase() + ".png");

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorDropdownButton.java
@@ -14,6 +14,8 @@ import by.dragonsurvivalteam.dragonsurvival.mixins.AccessorScreen;
 import com.mojang.blaze3d.systems.RenderSystem;
 import java.util.List;
 import java.util.Objects;
+
+import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.ContainerObjectSelectionList;
@@ -29,9 +31,7 @@ public class DragonEditorDropdownButton extends DropDownButton{
 
 	public DragonEditorDropdownButton(DragonEditorScreen dragonEditorScreen, int x, int y, int xSize, int ySize, String current, String[] values, EnumSkinLayer layers){
 		super(x, y, xSize, ySize, current, values, selected -> {
-			dragonEditorScreen.preset.skinAges.get(dragonEditorScreen.level).get().layerSettings.get(layers).get().selectedSkin = DragonEditorScreen.partToTechnical(selected);
-			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-			dragonEditorScreen.update();
+			dragonEditorScreen.actionHistory.add(new DragonEditorScreen.EditorAction<>(dragonEditorScreen.dragonPartSelectAction, new Pair<>(layers, selected)));
 		});
 		this.dragonEditorScreen = dragonEditorScreen;
 		this.layers = layers;
@@ -125,12 +125,6 @@ public class DragonEditorDropdownButton extends DropDownButton{
 			((AccessorScreen)screen).children().add(renderButton);
 			screen.renderables.add(renderButton);
 		}else{
-			LayerSettings settings = dragonEditorScreen.preset.skinAges.get(dragonEditorScreen.level).get().layerSettings.get(layers).get();
-			DragonEditorObject.DragonTextureMetadata text = DragonEditorHandler.getSkinTextureMetadata(FakeClientPlayerUtils.getFakePlayer(0, DragonEditorScreen.HANDLER), layers, settings.selectedSkin, dragonEditorScreen.dragonType);
-			if (text != null && !settings.modifiedColor) {
-				settings.hue = text.average_hue;
-			}
-
 			screen.children().removeIf(s -> s == list || s == renderButton);
 			screen.renderables.removeIf(s -> s == list || s == renderButton);
 		}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorSlotButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonEditorSlotButton.java
@@ -5,6 +5,8 @@ import by.dragonsurvivalteam.dragonsurvival.client.skin_editor_system.DragonEdit
 import by.dragonsurvivalteam.dragonsurvival.client.util.TextRenderUtil;
 import java.awt.*;
 import java.util.HashMap;
+import java.util.function.Function;
+
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
@@ -14,23 +16,29 @@ import org.jetbrains.annotations.NotNull;
 public class DragonEditorSlotButton extends Button{
 	private final DragonEditorScreen screen;
 	public int num;
+	private final Function<Integer, Integer> setDragonSlotAction;
 
 	public DragonEditorSlotButton(int p_i232255_1_, int p_i232255_2_, int num, DragonEditorScreen parent){
 		super(p_i232255_1_, p_i232255_2_, 12, 12, Component.empty(), btn -> {}, DEFAULT_NARRATION);
 		this.num = num;
 		screen = parent;
+		setDragonSlotAction = slot -> {
+			int prevSlot = screen.currentSelected;
+			if(screen.dragonType != null){
+				DragonEditorRegistry.getSavedCustomizations().skinPresets.computeIfAbsent(screen.dragonType.getTypeNameUpperCase(), t -> new HashMap<>());
+				DragonEditorRegistry.getSavedCustomizations().skinPresets.get(screen.dragonType.getTypeNameUpperCase()).put(screen.currentSelected, screen.preset);
+			}
+
+			screen.currentSelected = slot;
+			screen.update();
+			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+			return prevSlot;
+		};
 	}
 
 	@Override
 	public void onPress(){
-		if(screen.dragonType != null){
-			DragonEditorRegistry.getSavedCustomizations().skinPresets.computeIfAbsent(screen.dragonType.getTypeNameUpperCase(), t -> new HashMap<>());
-			DragonEditorRegistry.getSavedCustomizations().skinPresets.get(screen.dragonType.getTypeNameUpperCase()).put(screen.currentSelected, screen.preset);
-		}
-
-		screen.currentSelected = num - 1;
-		screen.update();
-		DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+		screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(setDragonSlotAction, num - 1));
 	}
 
 	@Override

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/NewbornEditorButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/NewbornEditorButton.java
@@ -14,10 +14,7 @@ public class NewbornEditorButton extends Button{
 
 	public NewbornEditorButton(DragonEditorScreen dragonEditorScreen){
 		super(dragonEditorScreen.width / 2 - 180, dragonEditorScreen.guiTop - 30, 120, 20, Component.translatable("ds.level.newborn"), btn -> {
-			dragonEditorScreen.level = DragonLevel.NEWBORN;
-			dragonEditorScreen.dragonRender.zoom = dragonEditorScreen.level.size * 3 - 5;
-			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-			dragonEditorScreen.update();
+			dragonEditorScreen.actionHistory.add(new DragonEditorScreen.EditorAction<>(dragonEditorScreen.selectLevelAction, DragonLevel.NEWBORN));
 		}, DEFAULT_NARRATION);
 		this.dragonEditorScreen = dragonEditorScreen;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/YoungEditorButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/YoungEditorButton.java
@@ -14,10 +14,7 @@ public class YoungEditorButton extends Button{
 
 	public YoungEditorButton(DragonEditorScreen dragonEditorScreen){
 		super(dragonEditorScreen.width / 2 - 60, dragonEditorScreen.guiTop - 30, 120, 20, Component.translatable("ds.level.young"), btn -> {
-			dragonEditorScreen.level = DragonLevel.YOUNG;
-			dragonEditorScreen.dragonRender.zoom = dragonEditorScreen.level.size * 2;
-			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-			dragonEditorScreen.update();
+			dragonEditorScreen.actionHistory.add(new DragonEditorScreen.EditorAction<>(dragonEditorScreen.selectLevelAction, DragonLevel.YOUNG));
 		}, DEFAULT_NARRATION);
 		this.dragonEditorScreen = dragonEditorScreen;
 	}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/CopyEditorSettingsComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/CopyEditorSettingsComponent.java
@@ -79,6 +79,8 @@ public class CopyEditorSettingsComponent extends AbstractContainerEventHandler i
 
 				screen.update();
 				btn.onPress();
+				// TODO: We don't support undoing this action at this time, so to prevent weird behavior it clears the undo/redo stack
+				screen.actionHistory.clear();
 			}
 		};
 		confirm.setTooltip(Tooltip.create(Component.translatable("ds.gui.dragon_editor.tooltip.done")));

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/HueSelectorComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/HueSelectorComponent.java
@@ -14,7 +14,11 @@ import by.dragonsurvivalteam.dragonsurvival.client.util.RenderingUtils;
 import com.google.common.collect.ImmutableList;
 import java.awt.*;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
+
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.AbstractContainerEventHandler;
@@ -40,6 +44,10 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 	private final ExtendedSlider hueSlider;
 	private final ExtendedSlider saturationSlider;
 	private final ExtendedSlider brightnessSlider;
+
+	private boolean hasModifiedColor(DragonEditorObject.DragonTextureMetadata texture) {
+		return texture != null && (Float.compare(Math.round(settings.get().hue * 360), Math.round(texture.average_hue * 360)) != 0 || !(Math.abs(settings.get().saturation - 0.5f) < 0.05) || !(Math.abs(settings.get().brightness  - 0.5f) < 0.05));
+	}
 
 	public HueSelectorComponent(DragonEditorScreen screen, int x, int y, int xSize, int ySize, EnumSkinLayer layer){
         this.x = x;
@@ -70,21 +78,23 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 		}
 
 		hueSlider = new ExtendedSlider(x + 3, y + 24, xSize - 26, 20, Component.empty(), Component.empty(), 0, 360, hsb[0] * 360.0f, true){
+			private int previousHue = 0;
+
+			private final Function<Integer, Integer> setHueAction = value -> {
+				settings.get().hue = value / 360f;
+				settings.get().modifiedColor = hasModifiedColor(text);
+
+				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+				screen.update();
+
+				return previousHue;
+			};
+
 			@Override
 			protected void applyValue(){
 				super.applyValue();
 
-				float value = (hueSlider.getValueInt()) / 360f;
-				float value1 = (saturationSlider.getValueInt()) / 360f;
-				float value2 = (brightnessSlider.getValueInt()) / 360f;
-
-				settings.get().hue = value;
-				settings.get().saturation = value1;
-				settings.get().brightness = value2;
-                settings.get().modifiedColor = text != null && (Float.compare(Math.round(value * 360), Math.round(text.average_hue * 360)) != 0 || !(Math.abs(value1 - 0.5f) < 0.05) || !(Math.abs(value2 - 0.5f) < 0.05));
-
-				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-				screen.update();
+				setHueAction.apply(this.getValueInt());
 			}
 
 			@Override
@@ -98,6 +108,18 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 				RenderingUtils.renderPureColorSquare(guiGraphics.pose(), getX(), getY(), getWidth(), getHeight());
 				guiGraphics.blitSprite(this.getSprite(), this.getX() + (int)(this.value * (double)(this.width - 8)), this.getY(), 8, this.height);
 			}
+
+			@Override
+			public void onClick(double mouseX, double mouseY) {
+				super.onClick(mouseX, mouseY);
+				previousHue = this.getValueInt();
+			}
+
+			@Override
+			public void onRelease(double mouseX, double mouseY) {
+				super.onRelease(mouseX, mouseY);
+				screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(setHueAction, this.getValueInt()));
+			}
 		};
 
 		hueReset = new ExtendedButton(x + 3 + xSize - 26, y + 24, 20, 20, Component.empty(), button -> hueSlider.setValue(text != null ? Math.round(text.average_hue * 360f) : 180)) {
@@ -109,22 +131,23 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 		};
 
 		saturationSlider = new ExtendedSlider(x + 3, y + 22 + 24, xSize - 26, 20, Component.empty(), Component.empty(), 0, 360, hsb[1] * 360, true){
+			private int previousSaturation = 0;
+
+			private final Function<Integer, Integer> setSaturationAction = value -> {
+				settings.get().saturation = value / 360f;
+				settings.get().modifiedColor = hasModifiedColor(text);
+
+				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+				screen.update();
+
+				return previousSaturation;
+			};
+
 			@Override
 			protected void applyValue(){
 				super.applyValue();
 
-				float value = (hueSlider.getValueInt()) / 360f;
-				float value1 = (saturationSlider.getValueInt()) / 360f;
-				float value2 = (brightnessSlider.getValueInt()) / 360f;
-
-				settings.get().hue = value;
-				settings.get().saturation = value1;
-				settings.get().brightness = value2;
-
-				settings.get().modifiedColor = text != null && (Float.compare(Math.round(value * 360), Math.round(text.average_hue * 360)) != 0 || !(Math.abs(value1 - 0.5f) < 0.05) || !(Math.abs(value2 - 0.5f) < 0.05));
-
-				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-				screen.update();
+				setSaturationAction.apply(this.getValueInt());
 			}
 
 			@Override
@@ -146,6 +169,18 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 					guiGraphics.blitSprite(this.getSprite(), this.getX() + (int)(this.value * (double)(this.width - 8)), this.getY(), 8, this.height);
 				}
 			}
+
+			@Override
+			public void onRelease(double mouseX, double mouseY) {
+				super.onRelease(mouseX, mouseY);
+				screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(setSaturationAction, this.getValueInt()));
+			}
+
+			@Override
+			public void onClick(double mouseX, double mouseY) {
+				super.onClick(mouseX, mouseY);
+				previousSaturation = this.getValueInt();
+			}
 		};
 
 		saturationReset = new ExtendedButton(x + 3 + xSize - 26, y + 22 + 24, 20, 20, Component.empty(), button -> saturationSlider.setValue(180)) {
@@ -156,22 +191,24 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 			}
 		};
 
+
 		brightnessSlider = new ExtendedSlider(x + 3, y + 44 + 24, xSize - 26, 20, Component.empty(), Component.empty(), 0, 360, hsb[2] * 360, true){
+			private int previousBrightness = 0;
+
+			private final Function<Integer, Integer> setBrightnessAction = value -> {
+				settings.get().brightness = value / 360f;
+
+				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+				screen.update();
+
+				return previousBrightness;
+			};
+
 			@Override
 			protected void applyValue(){
 				super.applyValue();
 
-				float value = (hueSlider.getValueInt()) / 360f;
-				float value1 = (saturationSlider.getValueInt()) / 360f;
-				float value2 = (brightnessSlider.getValueInt()) / 360f;
-
-				settings.get().hue = value;
-				settings.get().saturation = value1;
-				settings.get().brightness = value2;
-				settings.get().modifiedColor = text != null && (Float.compare(Math.round(value * 360), Math.round(text.average_hue * 360)) != 0 || !(Math.abs(value1 - 0.5f) < 0.05) || !(Math.abs(value2 - 0.5f) < 0.05));
-
-				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-				screen.update();
+				setBrightnessAction.apply(this.getValueInt());
 			}
 
 			@Override
@@ -192,6 +229,18 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 					RenderingUtils.drawGradientRect(guiGraphics.pose().last().pose(), 0, getX(), getY(), getX() + getWidth(), getY() + getHeight(), new int[]{col2, col1, col1, col2});
 					guiGraphics.blitSprite(this.getSprite(), this.getX() + (int)(this.value * (double)(this.width - 8)), this.getY(), 8, this.height);
 				}
+			}
+
+			@Override
+			public void onRelease(double mouseX, double mouseY) {
+				super.onRelease(mouseX, mouseY);
+				screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(setBrightnessAction, this.getValueInt()));
+			}
+
+			@Override
+			public void onClick(double mouseX, double mouseY) {
+				super.onClick(mouseX, mouseY);
+				previousBrightness = this.getValueInt();
 			}
 		};
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/HueSelectorComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/HueSelectorComponent.java
@@ -59,11 +59,21 @@ public class HueSelectorComponent extends AbstractContainerEventHandler implemen
 		LayerSettings set = settings.get();
 		DragonEditorObject.DragonTextureMetadata text = DragonEditorHandler.getSkinTextureMetadata(FakeClientPlayerUtils.getFakePlayer(0, DragonEditorScreen.HANDLER), layer, set.selectedSkin, DragonEditorScreen.HANDLER.getType());
 
-		glowing = new ExtendedCheckbox(x + 3, y, 20, 20, 20, Component.translatable("ds.gui.dragon_editor.glowing"), set.glowing, box -> {
-			settings.get().glowing = !settings.get().glowing;
-			box.selected = settings.get().glowing;
-			DragonEditorScreen.HANDLER.getSkinData().compileSkin();
-		});
+
+		glowing = new ExtendedCheckbox(x + 3, y, 20, 20, 20, Component.translatable("ds.gui.dragon_editor.glowing"), set.glowing, box -> {}){
+			final Function<Boolean, Boolean> setGlowingAction = value -> {
+				settings.get().glowing = value;
+				this.selected = settings.get().glowing;
+				DragonEditorScreen.HANDLER.getSkinData().compileSkin();
+				screen.update();
+				return !value;
+			};
+
+			@Override
+			public void onPress(){
+				screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(setGlowingAction, !settings.get().glowing));
+			}
+		};
 
 		float[] hsb = new float[]{set.hue, set.saturation, set.brightness};
 


### PR DESCRIPTION
Rewrote the entire redo/undo implementation to be way more robust and actually work in a way that would be expected. The only button that you might expect to have a redo/undo stack that still doesn't is the copy to other growth stages button.