### PR TITLE
Adjustments to datapack dragon stage logic

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/hud/GrowthHUD.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/hud/GrowthHUD.java
@@ -60,7 +60,7 @@ public class GrowthHUD {
 
         Holder<DragonStage> dragonStage = handler.getStage();
         double growth = DragonGrowthHandler.getGrowth(handler.getStage(), stack.getItem());
-        double nextSize = dragonStage.value().getNextSize(localPlayer.registryAccess(), handler.getSize() + growth);
+        double nextSize = dragonStage.value().getNextSize(localPlayer.registryAccess(), handler.getSize() + growth, handler.previousStage != null ? handler.previousStage.value() : null);
 
         if (handler.getSize() == nextSize) {
             return;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/DragonAltarScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/DragonAltarScreen.java
@@ -24,6 +24,7 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.LivingEntity;
@@ -165,7 +166,8 @@ public class DragonAltarScreen extends Screen {
 
         handler.setHasFlight(true);
         //noinspection DataFlowIssue -> registry is expected to be present
-        handler.setClientSize(CommonHooks.resolveLookup(DragonStage.REGISTRY).getOrThrow(DragonStages.adult));
+        Holder.Reference<DragonStage> dragonStage = CommonHooks.resolveLookup(DragonStage.REGISTRY).getOrThrow(DragonStages.adult);
+        handler.setClientSize(dragonStage, dragonStage.value().sizeRange().min());
         handler.getSkinData().get(handler.getStage().getKey()).get().defaultSkin = true;
     }
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -901,12 +901,14 @@ public class DragonEditorScreen extends Screen implements DragonBodyScreen {
             data.setType(dragonType, minecraft.player);
             data.setBody(dragonBody, minecraft.player);
 
-            double size = data.getSavedDragonSize(data.getTypeName()); // TODO level :: add level to saved data (and dragon soul?)
+            DragonStateHandler.SavedDragonStage savedDragonStage = data.getSavedDragonStage(data.getTypeName());
 
-            if (!ServerConfig.saveGrowthStage || size == DragonStateHandler.NO_SIZE) {
-                data.setClientSize(minecraft.player.registryAccess().holderOrThrow(DragonStages.newborn));
+            if (!ServerConfig.saveGrowthStage || savedDragonStage == null) {
+                Holder<DragonStage> dragonStage = minecraft.player.registryAccess().holderOrThrow(DragonStages.newborn);
+                data.setClientSize(dragonStage, dragonStage.value().sizeRange().min());
             } else {
-                data.setClientSize(size);
+                data.previousStage = savedDragonStage.previousStage();
+                data.setClientSize(savedDragonStage.dragonStage(), savedDragonStage.size());
             }
 
             data.setHasFlight(ServerFlightHandler.startWithFlight || ServerConfig.saveGrowthStage && data.hasFlight());

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/DragonEditorScreen.java
@@ -212,9 +212,9 @@ public class DragonEditorScreen extends Screen implements DragonBodyScreen {
         return (float) (0.4 * dragonStage.value().sizeRange().min() + 20);
     }
 
-    public final Function<Holder<DragonStage>, Holder<DragonStage>> selectLevelAction = (newLevel) -> {
+    public final Function<Holder<DragonStage>, Holder<DragonStage>> selectStageAction = newStage -> {
         Holder<DragonStage> previousLevel = dragonStage;
-        dragonStage = newLevel;
+        dragonStage = newStage;
         dragonRender.zoom = setZoom(dragonStage);
         HANDLER.getSkinData().compileSkin(dragonStage);
         update();
@@ -438,12 +438,12 @@ public class DragonEditorScreen extends Screen implements DragonBodyScreen {
 
         String type = dragonType.getTypeNameLowerCase();
         SavedSkinPresets savedCustomizations = DragonEditorRegistry.getSavedCustomizations(null);
-        String levelLocation = Objects.requireNonNull(dragonStage.getKey()).location().toString();
+        String stageLocation = Objects.requireNonNull(dragonStage.getKey()).location().toString();
 
         savedCustomizations.current.computeIfAbsent(type, key -> new HashMap<>());
-        savedCustomizations.current.get(type).putIfAbsent(levelLocation, 0);
+        savedCustomizations.current.get(type).putIfAbsent(stageLocation, 0);
 
-        selectedSaveSlot = savedCustomizations.current.get(type).get(levelLocation);
+        selectedSaveSlot = savedCustomizations.current.get(type).get(stageLocation);
 
         savedCustomizations.skinPresets.computeIfAbsent(type, key -> new HashMap<>());
         savedCustomizations.skinPresets.get(type).computeIfAbsent(selectedSaveSlot, key -> {
@@ -458,11 +458,13 @@ public class DragonEditorScreen extends Screen implements DragonBodyScreen {
         preset = new SkinPreset();
         preset.deserializeNBT(Objects.requireNonNull(Minecraft.getInstance().player).registryAccess(), currentPreset.serializeNBT(Minecraft.getInstance().player.registryAccess()));
 
-        HANDLER.getSkinData().skinPreset = preset;
-        HANDLER.getSkinData().compileSkin(dragonStage);
         HANDLER.setHasFlight(true);
         HANDLER.setType(dragonType);
+        HANDLER.setClientSize(dragonStage, dragonStage.value().sizeRange().min());
         HANDLER.setBody(dragonBody);
+
+        HANDLER.getSkinData().skinPreset = preset;
+        HANDLER.getSkinData().compileSkin(dragonStage);
 
         dragonRender.zoom = setZoom(dragonStage);
     }
@@ -836,7 +838,7 @@ public class DragonEditorScreen extends Screen implements DragonBodyScreen {
 
         HANDLER.setBody(dragonBody);
         HANDLER.getSkinData().skinPreset = preset;
-        HANDLER.setClientSize(dragonStage);
+        HANDLER.setClientSize(dragonStage, dragonStage.value().sizeRange().min());
         HANDLER.setHasFlight(true);
 
         if (selectedSaveSlot != lastSelected) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonStageButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/screens/dragon_editor/buttons/DragonStageButton.java
@@ -20,7 +20,7 @@ public class DragonStageButton extends Button {
     public DragonStageButton(final DragonEditorScreen screen, final ResourceKey<DragonStage> dragonStage, int xOffset) {
         super(screen.width / 2 + xOffset, screen.guiTop - 30, 120, 20, DragonStage.translatableName(dragonStage), button -> {
             //noinspection DataFlowIssue -> registry is expected to be present
-            screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(screen.selectLevelAction, CommonHooks.resolveLookup(DragonStage.REGISTRY).getOrThrow(dragonStage)));
+            screen.actionHistory.add(new DragonEditorScreen.EditorAction<>(screen.selectStageAction, CommonHooks.resolveLookup(DragonStage.REGISTRY).getOrThrow(dragonStage)));
         }, DEFAULT_NARRATION);
 
         this.screen = screen;
@@ -31,6 +31,6 @@ public class DragonStageButton extends Button {
     public void renderWidget(@NotNull final GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         active = visible = screen.showUi;
         int color = isHovered || screen.dragonStage.is(dragonStage) ? WHITE : LIGHT_GRAY;
-        TextRenderUtil.drawCenteredScaledText(graphics, getX() + width / 2, getY() + 4, 1.5f, getMessage().getString(), color); // TODO :: previously used alpha - but does that ever change for this widget?
+        TextRenderUtil.drawCenteredScaledText(graphics, getX() + width / 2, getY() + 4, 1.5f, getMessage().getString(), color);
     }
 }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/DragonUIRenderComponent.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/components/DragonUIRenderComponent.java
@@ -52,7 +52,7 @@ public class DragonUIRenderComponent extends AbstractContainerEventHandler imple
 
         // We need to translate this backwards with the poseStack as renderEntityInInventory pushes the poseStack forward
         guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(0, 0, -200); // We chose -200 here as the background is translated -300 and we don't want to clip with it
+        guiGraphics.pose().translate(0, 0, -200); // We chose -200 here as the background is translated -300, and we don't want to clip with it
 
         Quaternionf quaternion = Axis.ZP.rotationDegrees(180);
         quaternion.mul(Axis.XP.rotationDegrees(yRot * 10));

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/DragonSkins.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/DragonSkins.java
@@ -268,7 +268,7 @@ public class DragonSkins {
                     skin.glow = isGlow;
                     SKIN_USERS.get(dragonStage).putIfAbsent(name, skin);
                 } catch (ResourceLocationException exception) {
-                    DragonSurvival.LOGGER.warn("Could not parse dragon level from the skin [{}]", skin.name, exception);
+                    DragonSurvival.LOGGER.warn("Could not parse dragon stage from the skin [{}] due to [{}]", skin.name, exception.getMessage());
                 }
             }
         }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonCommand.java
@@ -122,7 +122,7 @@ public class DragonCommand {
 
         cap.setType(dragonType, player);
         cap.setBody(dragonBody, player);
-        cap.setSize(player, dragonStage);
+        cap.setSize(player, dragonStage, dragonStage != null ? dragonStage.value().sizeRange().min() : DragonStateHandler.NO_SIZE);
 
         cap.setHasFlight(flight);
         cap.getMovementData().spinLearned = flight;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonSizeCommand.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/commands/DragonSizeCommand.java
@@ -3,6 +3,7 @@ package by.dragonsurvivalteam.dragonsurvival.commands;
 import by.dragonsurvivalteam.dragonsurvival.commands.arguments.DragonSizeArgument;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
+import by.dragonsurvivalteam.dragonsurvival.registry.dragon.DragonStage;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
@@ -24,7 +25,13 @@ public class DragonSizeCommand {
             DragonStateHandler handler = DragonStateProvider.getData(serverPlayer);
 
             if (handler.isDragon()) {
-                handler.setSize(serverPlayer, handler.getStage(), size);
+                if (handler.getStage().value().sizeRange().matches(size)) {
+                    // If the min. size of the next stage is set it can look like a bug
+                    // (Because after 1 second of running the command the stage changes due to the natural growth)
+                    handler.setSize(serverPlayer, handler.getStage(), size);
+                } else {
+                    handler.setSize(serverPlayer, DragonStage.get(serverPlayer.registryAccess(), size), size);
+                }
             }
 
             return 1;

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -148,10 +148,10 @@ public class DragonStateHandler extends EntityStateHandler {
     }
 
     public void setClientSize(@Nullable final Holder<DragonStage> dragonStage, double size) {
-        Holder<DragonStage> oldLevel = this.dragonStage;
+        Holder<DragonStage> oldStage = this.dragonStage;
         updateSizeAndStage(null, dragonStage, size);
 
-        if (oldLevel == null || this.dragonStage != null && !this.dragonStage.is(oldLevel)) {
+        if (oldStage == null || this.dragonStage != null && !this.dragonStage.is(oldStage)) {
             if (FMLEnvironment.dist.isClient()) { // When deserializing nbt there is no player context
                 // Only need to update when the level changes (for the skin)
                 ClientProxy.sendClientData();
@@ -549,7 +549,9 @@ public class DragonStateHandler extends EntityStateHandler {
             getMovementData().spinCooldown = tag.getInt("spinCooldown");
             getMovementData().spinAttack = tag.getInt("spinAttack");
 
-            setClientSize(dragonStage, size);
+            // Make sure a stage is set if the player was deserialized as a dragon
+            // It could be missing here if the NBT is loaded from an old save
+            setClientSize(dragonStage != null ? dragonStage : DragonStage.get(provider, size), size);
 
             setDestructionEnabled(tag.getBoolean("destructionEnabled"));
             isGrowing = !tag.contains(IS_GROWING) || tag.getBoolean(IS_GROWING);

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -194,29 +194,34 @@ public class DragonStateHandler extends EntityStateHandler {
         if (dragonStage == null || size == NO_SIZE) {
             this.dragonStage = null;
             this.size = NO_SIZE;
-        } else if (!dragonStage.value().sizeRange().matches(size)) {
-            if (size > dragonStage.value().sizeRange().max()) {
+            return;
+        }
+
+        double newSize = DragonStage.getValidSize(size);
+
+        if (!dragonStage.value().sizeRange().matches(newSize)) {
+            if (newSize > dragonStage.value().sizeRange().max()) {
                 Optional<Holder.Reference<DragonStage>> nextStage = DragonStage.getNextStage(provider, dragonStage.value());
 
                 // Find the next dragon stage in the chain that matches with the given size
                 while (nextStage.isPresent()) {
                     this.dragonStage = nextStage.get();
 
-                    if (!this.dragonStage.value().sizeRange().matches(size)) {
+                    if (!this.dragonStage.value().sizeRange().matches(newSize)) {
                         nextStage = DragonStage.getNextStage(provider, dragonStage.value());
                     } else {
                         nextStage = Optional.empty();
                     }
                 }
             } else {
-                this.dragonStage = Objects.requireNonNullElseGet(previousStage, () -> DragonStage.get(provider, size));
+                this.dragonStage = Objects.requireNonNullElseGet(previousStage, () -> DragonStage.get(provider, newSize));
             }
 
-            this.size = this.dragonStage.value().getBoundedSize(size);
         } else {
             this.dragonStage = dragonStage;
-            this.size = this.dragonStage.value().getBoundedSize(size);
         }
+
+        this.size = this.dragonStage.value().getBoundedSize(newSize);
     }
 
     public @Nullable SavedDragonStage getSavedDragonStage(final String dragonType) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -195,7 +196,18 @@ public class DragonStateHandler extends EntityStateHandler {
             this.size = NO_SIZE;
         } else if (!dragonStage.value().sizeRange().matches(size)) {
             if (size > dragonStage.value().sizeRange().max()) {
-                DragonStage.getNextStage(provider, dragonStage.value()).ifPresent(nextStage -> this.dragonStage = nextStage);
+                Optional<Holder.Reference<DragonStage>> nextStage = DragonStage.getNextStage(provider, dragonStage.value());
+
+                // Find the next dragon stage in the chain that matches with the given size
+                while (nextStage.isPresent()) {
+                    this.dragonStage = nextStage.get();
+
+                    if (!this.dragonStage.value().sizeRange().matches(size)) {
+                        nextStage = DragonStage.getNextStage(provider, dragonStage.value());
+                    } else {
+                        nextStage = Optional.empty();
+                    }
+                }
             } else {
                 this.dragonStage = Objects.requireNonNullElseGet(previousStage, () -> DragonStage.get(provider, size));
             }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonGrowthHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/handlers/DragonGrowthHandler.java
@@ -46,7 +46,7 @@ public class DragonGrowthHandler {
             return;
         }
 
-        double newSize = data.getStage().value().getNextSize(player.registryAccess(), data.getSize() + growth);
+        double newSize = data.getStage().value().getNextSize(player.registryAccess(), data.getSize() + growth, data.previousStage != null ? data.previousStage.value() : null);
 
         if (data.getSize() == newSize) {
             player.sendSystemMessage(Component.translatable(growth > 0 ? REACHED_LARGEST : REACHED_SMALLEST).withStyle(ChatFormatting.RED));
@@ -86,7 +86,7 @@ public class DragonGrowthHandler {
         }
 
         DragonStage dragonStage = data.getStage().value();
-        double nextSize = dragonStage.getNextSize(serverPlayer.registryAccess(), data.getSize() + dragonStage.ticksToSize(getInterval()));
+        double nextSize = dragonStage.getNextSize(serverPlayer.registryAccess(), data.getSize() + dragonStage.ticksToSize(getInterval()), data.previousStage != null ? data.previousStage.value() : null);
         Optional<EntityPredicate> isNaturalGrowthStopped = dragonStage.isNaturalGrowthStopped();
 
         if (nextSize == data.getSize() || isNaturalGrowthStopped.isPresent() && isNaturalGrowthStopped.get().matches(serverPlayer.serverLevel(), serverPlayer.position(), serverPlayer)) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/gametests/TestUtils.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/gametests/TestUtils.java
@@ -67,9 +67,9 @@ public class TestUtils {
         data.setBody(body, player);
         helper.assertTrue(DragonUtils.isBody(data, body), String.format("Dragon type was [%s] - expected [%s]", data.getBody(), dragonBody));
 
-        Holder<DragonStage> level = player.registryAccess().holderOrThrow(dragonStage);
-        data.setSize(player, level);
-        helper.assertTrue(data.getStage().is(level), String.format("Dragon level was [%s] - expected [%s]", data.getStage().getKey().location(), level.getKey().location()));
+        Holder<DragonStage> stage = player.registryAccess().holderOrThrow(dragonStage);
+        data.setSize(player, stage, stage.value().sizeRange().min());
+        helper.assertTrue(data.getStage().is(stage), String.format("Dragon stage was [%s] - expected [%s]", data.getStage().getKey().location(), stage.getKey().location()));
 
         helper.assertTrue(data.isDragon(), "Player is not a dragon - expected player to be a dragon");
     }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/network/client/ClientProxy.java
@@ -74,6 +74,7 @@ public class ClientProxy {
         Player localPlayer = Minecraft.getInstance().player;
 
         if (localPlayer == null) {
+            // This check is needed since in single player the server thread will go in here (from 'deserializeNBT')
             return;
         }
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/dragon/DragonStage.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/dragon/DragonStage.java
@@ -88,7 +88,7 @@ public record DragonStage(
         }
 
         StringBuilder nextStageCheck = new StringBuilder("The following stages are incorrectly defined:");
-        AtomicBoolean areStagesValid = new AtomicBoolean();
+        AtomicBoolean areStagesValid = new AtomicBoolean(true);
 
         keys(provider).forEach(key -> {
             //noinspection OptionalGetWithoutIsPresent -> ignore
@@ -175,7 +175,21 @@ public record DragonStage(
 
     /** Returns {@link DragonStage#getBoundedSize(double)} of the next stage (if present) or of the current stage */
     public double getNextSize(@Nullable final HolderLookup.Provider provider, double size) {
-        return getNextStage(provider, this).map(nextStage -> nextStage.value().getBoundedSize(size)).orElse(getBoundedSize(size));
+        if (!getBounds().matches(size)) {
+            Optional<Holder.Reference<DragonStage>> nextStage = getNextStage(provider, this);
+
+            if (nextStage.isEmpty()) {
+                return size;
+            }
+
+            if (!nextStage.get().value().sizeRange().matches(size)) {
+                return size;
+            }
+
+            return nextStage.get().value().getBoundedSize(size);
+        }
+
+        return size;
     }
 
     /** Returns the bounds between the smallest and largest dragon sizes */

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/dragon/DragonStage.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/registry/dragon/DragonStage.java
@@ -164,7 +164,15 @@ public record DragonStage(
         return Math.clamp(size, sizeRange().min(), sizeRange().max());
     }
 
-    /** Returns the next size (either part of the next stage chain, of the previous stage or the current size - depending on whether the size matches the bounds) */
+    /**
+     * Returns a valid size (see {@link DragonStage#getValidSize(double)}) <br>
+     * <br> If the size is larger than the max. size of the current dragon stage: <br>
+     *   - The {@link DragonStage#getBoundedSize(double)} of the matching dragon stage of the next dragon stage chain <br>
+     * <br> If the size is smaller than the min. size of the current dragon stage: <br>
+     *   - The current (valid) size if a previous stage is present, and its size bounds matches the current size <br>
+     *   - The {@link DragonStage#getBoundedSize(double)} of a matching dragon stage <br>
+     * <br> Otherwise (if the size is within the bounds of the current stage) the current (valid) size will be returned
+     */
     public double getNextSize(@Nullable final HolderLookup.Provider provider, double size, @Nullable final DragonStage previousStage) {
         double newSize = getValidSize(size);
 
@@ -181,6 +189,7 @@ public record DragonStage(
         return newSize;
     }
 
+    /** Returns a valid size (meaning a size within the bounds of the smallest and largest dragon) */
     public static double getValidSize(double size) {
         return Math.clamp(size, smallest.sizeRange.min(), largest.sizeRange().max());
     }


### PR DESCRIPTION
+ add logic to retain previous stage (e.g. when growth items are used to go back and forth stages)
+ adjust the saved dragon size logic to also retain stage and previous stage

currently there is a warning if the deserialized dragon stage is no longer present
since `isDragon()` checks for type, body and stage a "random" one is then fetched based on the size

(This also already happens for the body)