### PR TITLE
Test out an idea for custom species support for dragon soul texture

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonSoulItem.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonSoulItem.java
@@ -1,5 +1,6 @@
 package by.dragonsurvivalteam.dragonsurvival.common.items;
 
+import by.dragonsurvivalteam.dragonsurvival.DragonSurvival;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateHandler;
 import by.dragonsurvivalteam.dragonsurvival.common.capability.DragonStateProvider;
 import by.dragonsurvivalteam.dragonsurvival.config.obj.ConfigOption;
@@ -10,7 +11,6 @@ import by.dragonsurvivalteam.dragonsurvival.network.syncing.SyncComplete;
 import by.dragonsurvivalteam.dragonsurvival.registry.DSAdvancementTriggers;
 import by.dragonsurvivalteam.dragonsurvival.registry.attachments.MagicData;
 import by.dragonsurvivalteam.dragonsurvival.registry.datagen.Translation;
-import by.dragonsurvivalteam.dragonsurvival.registry.datagen.tags.DSDragonSpeciesTags;
 import by.dragonsurvivalteam.dragonsurvival.registry.dragon.DragonSpecies;
 import by.dragonsurvivalteam.dragonsurvival.registry.dragon.stage.DragonStage;
 import by.dragonsurvivalteam.dragonsurvival.server.handlers.PlayerLoginHandler;
@@ -79,7 +79,6 @@ public class DragonSoulItem extends Item {
         }
     }
 
-    // TODO :: make compatible with custom species
     private static int getCustomModelData(@NotNull final HolderLookup.Provider provider, final CompoundTag tag) {
         ResourceKey<DragonSpecies> species = ResourceHelper.decodeKey(provider, DragonSpecies.REGISTRY, tag, DragonStateHandler.DRAGON_SPECIES);
 
@@ -87,17 +86,9 @@ public class DragonSoulItem extends Item {
             return 0;
         }
 
-        Holder<DragonSpecies> dragonSpecies = provider.holderOrThrow(species);
-
-        if (dragonSpecies.is(DSDragonSpeciesTags.FOREST_DRAGONS)) {
-            return 1;
-        } else if (dragonSpecies.is(DSDragonSpeciesTags.CAVE_DRAGONS)) {
-            return 2;
-        } else if (dragonSpecies.is(DSDragonSpeciesTags.SEA_DRAGONS)) {
-            return 3;
-        }
-
-        return 0;
+        int code = species.location().hashCode();
+        DragonSurvival.LOGGER.debug("Hashcode (for the dragon soul model predicate) of species [{}] is [{}]", species.location(), code);
+        return code;
     }
 
     @Override

--- a/src/main/resources/assets/dragonsurvival/models/item/dragon_soul.json
+++ b/src/main/resources/assets/dragonsurvival/models/item/dragon_soul.json
@@ -3,24 +3,69 @@
   "textures": {
     "layer0": "dragonsurvival:item/empty_soul"
   },
+  "_comment": [
+    "The check is: pick the first override whose number is not larger than the hashcode of the species",
+    "Therefor it is important to make sure the largest entry is at the bottom of this list",
+    "Because the order of the entries in the override list in-code go from bottom-to-top"
+  ],
   "overrides": [
     {
       "predicate": {
-        "custom_model_data": 1
-      },
-      "model": "dragonsurvival:item/forest_dragon_soul"
-    },
-    {
-      "predicate": {
-        "custom_model_data": 2
+        "custom_model_data": -368551212
       },
       "model": "dragonsurvival:item/cave_dragon_soul"
     },
     {
       "predicate": {
+        "custom_model_data": 0
+      },
+      "model": "dragonsurvival:item/empty_dragon_soul",
+      "_comment": "Only exists because the vanilla default value is 0 and would therefor apply to the potential lower values (like the one above)"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 1
+      },
+      "model": "dragonsurvival:item/forest_dragon_soul",
+      "_comment": "Only exists to be compatible with earlier versions - remove in 1.22"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 2
+      },
+      "model": "dragonsurvival:item/cave_dragon_soul",
+      "_comment": "Only exists to be compatible with earlier versions - remove in 1.22"
+    },
+    {
+      "predicate": {
         "custom_model_data": 3
       },
+      "model": "dragonsurvival:item/sea_dragon_soul",
+      "_comment": "Only exists to be compatible with earlier versions - remove in 1.22"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 179379154
+      },
       "model": "dragonsurvival:item/sea_dragon_soul"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 741619780
+      },
+      "model": "dragonsurvival:item/forest_dragon_soul"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 821731218
+      },
+      "model": "minecraft:item/iron_ingot"
+    },
+    {
+      "predicate": {
+        "custom_model_data": 1698877692
+      },
+      "model": "minecraft:item/diamond"
     }
   ]
 }

--- a/src/main/resources/assets/dragonsurvival/models/item/empty_dragon_soul.json
+++ b/src/main/resources/assets/dragonsurvival/models/item/empty_dragon_soul.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "dragonsurvival:item/empty_soul"
+  }
+}


### PR DESCRIPTION
It's mostly explained in the json how it works
Basically we always supply the hashcode of the species to the soul

That way we could pre-define species here of known addons
And modpack developers could do the same, adjusting the model file through a texture pack

---

### Example

I added bee (diamond) and griffin (iron ingot) to test it out
The relevant hashcode is printed in the debugger when using the soul:

```java
DragonSurvival.LOGGER.debug("Hashcode (for the dragon soul model predicate) of species [{}] is [{}]", species.location(), code);
```

<img width="436" height="138" alt="image" src="https://github.com/user-attachments/assets/cfacc463-a656-419d-a7f9-67cc7ded21c3" />


<img width="806" height="382" alt="image" src="https://github.com/user-attachments/assets/51d21215-28f7-484e-bc84-f5ed5de8cbb1" />

---

### Problem
If there is no value defined in the model json, then it will show the wrong icon instead of the (as of now) empty soul icon

I think this could only be fixed by not using the hashcode but rather add a new field in `MiscResources`
(And like the hashcode we could add these values in there, or (if missing) we return the default value 0 for the empty soul icon - like we do now)

Letting users self-define these values also has potential of clashing though because it is not guaranteed that they will use unique values (since they can't know every addon)

Maybe there is some option to parse the actual model file / get its content to check which species have been defined?
Allowing us to return the default value for the empty soul icon
