### PR TITLE
Refine dragon spin camera presentation

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -78,6 +78,25 @@ public class ClientFlightHandler {
     @ConfigOption(side = ConfigSide.CLIENT, category = "flight", key = "flight_camera_movement")
     public static Boolean flightCameraMovement = true;
 
+    @Translation(key = "spin_camera_effect", type = Translation.Type.CONFIGURATION, comments = "Enable / Disable camera punch and FOV changes while using spin as a dragon")
+    @ConfigOption(side = ConfigSide.CLIENT, category = "flight", key = "spin_camera_effect")
+    public static Boolean spinCameraEffect = true;
+
+    @ConfigRange(min = 0.0f, max = 0.5f)
+    @Translation(key = "spin_camera_entry_zoom_strength", type = Translation.Type.CONFIGURATION, comments = "How much the camera briefly tightens at the start of a spin")
+    @ConfigOption(side = ConfigSide.CLIENT, category = "flight", key = "spin_camera_entry_zoom_strength")
+    public static Float spinCameraEntryZoomStrength = 0.08f;
+
+    @ConfigRange(min = 0.0f, max = 0.5f)
+    @Translation(key = "spin_camera_travel_zoom_strength", type = Translation.Type.CONFIGURATION, comments = "How much the camera widens during the main travel phase of a spin")
+    @ConfigOption(side = ConfigSide.CLIENT, category = "flight", key = "spin_camera_travel_zoom_strength")
+    public static Float spinCameraTravelZoomStrength = 0.16f;
+
+    @ConfigRange(min = 0.0f, max = 0.5f)
+    @Translation(key = "spin_camera_fov_strength", type = Translation.Type.CONFIGURATION, comments = "How much the FOV expands during a spin")
+    @ConfigOption(side = ConfigSide.CLIENT, category = "flight", key = "spin_camera_fov_strength")
+    public static Float spinCameraFovStrength = 0.08f;
+
     @ConfigRange(min = 0.0f, max = 32.0f)
     @Translation(key = "base_dragon_camera_offset", type = Translation.Type.CONFIGURATION, comments = "Base offset for the dragon's third person camera (is multiplied and scaled by the other factors)")
     @ConfigOption(side = ConfigSide.CLIENT, category = {"rendering"}, key = "base_dragon_camera_offset")
@@ -142,6 +161,10 @@ public class ClientFlightHandler {
                 } else {
                     event.setDistance((event.getDistance() + baseDragonCameraOffset) / event.getEntityScalingFactor() * Math.max(visualScale, dragonCameraMinimumScale) * dragonCameraScaleFactor + flatDragonCameraOffset);
                 }
+
+                if (spinCameraEffect && event.getCamera().isDetached()) {
+                    event.setDistance(event.getDistance() + SpinFlightPresentation.getDetachedCameraOffset());
+                }
             }
         });
     }
@@ -159,6 +182,10 @@ public class ClientFlightHandler {
 
         if (currentPlayer != null && currentPlayer.isAddedToLevel() && DragonStateProvider.isDragon(currentPlayer)) {
             GameRenderer gameRenderer = minecraft.gameRenderer;
+            boolean shouldApplyZoom = false;
+            float targetZoom = 1.0F;
+            float zoomLerpFactor = 0.25F;
+            float partialTick = (float) setup.getPartialTick();
 
             if (ServerFlightHandler.isGliding(currentPlayer)) {
                 if (setup.getCamera().isDetached()) {
@@ -175,10 +202,8 @@ public class ClientFlightHandler {
                     if (flightZoomEffect) {
                         if (!minecraft.options.getCameraType().isFirstPerson()) {
                             Vec3 lookVec = currentPlayer.getLookAngle();
-                            float f = Math.min(Math.max(0.5F, 1F - (float) (lookVec.y * 5 / 2.5 * 0.5)), 3F);
-                            float newZoom = Mth.lerp(0.25f, lastZoom, f);
-                            gameRenderer.zoom = newZoom;
-                            lastZoom = newZoom;
+                            targetZoom = Math.min(Math.max(0.5F, 1F - (float) (lookVec.y * 5 / 2.5 * 0.5)), 3F);
+                            shouldApplyZoom = true;
                         }
                     }
                 }
@@ -190,12 +215,36 @@ public class ClientFlightHandler {
                     }
                 }
 
-                if (lastZoom != 1) {
-                    if (flightZoomEffect) {
-                        lastZoom = Mth.lerp(0.25f, lastZoom, 1f);
-                        gameRenderer.zoom = lastZoom;
+            }
+
+            if (spinCameraEffect) {
+                float spinZoom = SpinFlightPresentation.getZoomMultiplier(spinCameraEntryZoomStrength, spinCameraTravelZoomStrength);
+
+                if (!minecraft.options.getCameraType().isFirstPerson() && spinZoom != 1.0F) {
+                    targetZoom *= spinZoom;
+                    shouldApplyZoom = true;
+                }
+
+                zoomLerpFactor = Math.max(zoomLerpFactor, SpinFlightPresentation.getZoomLerpFactor());
+                setup.setPitch(setup.getPitch() + SpinFlightPresentation.getPitchOffset(currentPlayer, partialTick));
+                setup.setRoll(setup.getRoll() + SpinFlightPresentation.getRollOffset(currentPlayer, partialTick));
+
+                if (setup.getCamera().isDetached() && flightCameraMovement) {
+                    float spinCameraOffset = SpinFlightPresentation.getCameraLift() + SpinFlightPresentation.getCameraBobOffset(currentPlayer, partialTick);
+
+                    if (spinCameraOffset != 0.0F) {
+                        info.move(0.0F, spinCameraOffset, 0.0F);
                     }
                 }
+            }
+
+            if (shouldApplyZoom) {
+                float newZoom = Mth.lerp(zoomLerpFactor, lastZoom, targetZoom);
+                gameRenderer.zoom = newZoom;
+                lastZoom = newZoom;
+            } else if (lastZoom != 1.0F) {
+                lastZoom = Mth.lerp(zoomLerpFactor, lastZoom, 1.0F);
+                gameRenderer.zoom = lastZoom;
             }
         }
     }
@@ -513,15 +562,18 @@ public class ClientFlightHandler {
         LocalPlayer player = Minecraft.getInstance().player;
 
         if (player == null) {
+            SpinFlightPresentation.tick(null);
             return;
         }
 
         DragonStateHandler handler = DragonStateProvider.getData(player);
 
         if (!handler.isDragon()) {
+            SpinFlightPresentation.tick(null);
             return;
         }
 
+        SpinFlightPresentation.tick(player);
         jumpFlyCooldown.tick();
         boolean isJumping = Minecraft.getInstance().options.keyJump.isDown();
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/SpinFlightPresentation.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/SpinFlightPresentation.java
@@ -1,0 +1,218 @@
+package by.dragonsurvivalteam.dragonsurvival.client.handlers;
+
+import by.dragonsurvivalteam.dragonsurvival.registry.attachments.FlightData;
+import by.dragonsurvivalteam.dragonsurvival.server.handlers.ServerFlightHandler;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
+import org.jetbrains.annotations.Nullable;
+
+
+public final class SpinFlightPresentation {
+    private static final float ACTIVE_PROGRESS_LERP = 0.68F;
+    private static final float IDLE_PROGRESS_LERP = 0.20F;
+    private static final float ENTRY_PHASE_END = 0.30F;
+    private static final float EXIT_PHASE_START = 0.78F;
+    private static final float ENTRY_PUNCH_END = 0.10F;
+    private static final float FOV_RAMP_START = 0.08F;
+    private static final float FOV_RAMP_END = 0.34F;
+    private static final float CRUISE_RAMP_START = 0.12F;
+    private static final float CRUISE_RAMP_END = 0.45F;
+    private static final float INACTIVE_EPSILON = 0.0001F;
+
+    private static final float ENTRY_ZOOM_MULTIPLIER = 1.45F;
+    private static final float MIN_ZOOM = 0.55F;
+    private static final float MAX_ZOOM = 1.45F;
+    private static final float MIN_FOV_MULTIPLIER = 0.75F;
+    private static final float MAX_FOV_MULTIPLIER = 1.35F;
+
+    private static final float DETACHED_CAMERA_OFFSET = 1.15F;
+    private static final float CAMERA_LIFT = 0.14F;
+    private static final float EXIT_CAMERA_SETTLE = 0.03F;
+    private static final float ENTRY_PITCH = 2.35F;
+    private static final float SUSTAIN_PITCH = 0.28F;
+    private static final float EXIT_REBOUND_PITCH = 0.45F;
+    private static final float EXIT_ZOOM_REBOUND = 0.08F;
+    private static final float EXIT_FOV_SETTLE = 0.06F;
+    private static final float ROLL_SWAY = 0.32F;
+    private static final float ZOOM_LERP_MIN = 0.28F;
+    private static final float ZOOM_LERP_MAX = 0.74F;
+
+    private static final MotionProfile PITCH_MOTION = new MotionProfile(1.65F, 0.12F, 0.85F, 0.04F, 0.35F);
+    private static final MotionProfile ROLL_MOTION = new MotionProfile(1.95F, 0.18F, 1.10F, 0.05F, 1.20F);
+    private static final MotionProfile BOB_MOTION = new MotionProfile(2.25F, 0.014F, 1.45F, 0.006F, 2.40F);
+
+    private static final float ROLL_SWAY_FREQUENCY = 0.75F;
+    private static final float ROLL_SWAY_PHASE = 0.60F;
+    private static final float BOB_FREQUENCY = 1.90F;
+    private static final float BOB_PHASE = 1.10F;
+    private static final float BOB_AMPLITUDE = 0.018F;
+
+    private static float smoothedProgress;
+
+    private SpinFlightPresentation() {}
+
+    public static void tick(@Nullable final Player player) {
+        if (player == null) {
+            reset();
+            return;
+        }
+
+        boolean spinActive = ServerFlightHandler.isSpin(player);
+        float targetProgress = getRawProgress(player);
+        smoothedProgress = Mth.lerp(spinActive ? ACTIVE_PROGRESS_LERP : IDLE_PROGRESS_LERP, smoothedProgress, targetProgress);
+
+        if (!spinActive && isInactive()) {
+            reset();
+        }
+    }
+
+    public static float getZoomMultiplier(final float entryStrength, final float travelStrength) {
+        if (isInactive()) {
+            return 1.0F;
+        }
+
+        PhaseSample phase = getPhaseSample();
+        float entryPunch = 1.0F - easeOutCubic(getPhaseProgress(0.0F, ENTRY_PUNCH_END));
+        float zoom = 1.0F
+                + entryPunch * entryStrength * ENTRY_ZOOM_MULTIPLIER
+                - phase.travel() * travelStrength
+                + phase.exit() * travelStrength * EXIT_ZOOM_REBOUND;
+        return Mth.clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+    }
+
+    public static float getFovMultiplier(final float strength) {
+        if (isInactive()) {
+            return 1.0F;
+        }
+
+        float exit = getExitStrength();
+        float travel = getPhaseProgress(FOV_RAMP_START, FOV_RAMP_END) * (1.0F - exit);
+        float settle = exit * EXIT_FOV_SETTLE;
+        return Mth.clamp(1.0F + travel * strength - settle * strength, MIN_FOV_MULTIPLIER, MAX_FOV_MULTIPLIER);
+    }
+
+    public static float getDetachedCameraOffset() {
+        return isInactive() ? 0.0F : getTravelStrength() * DETACHED_CAMERA_OFFSET;
+    }
+
+    public static float getCameraLift() {
+        if (isInactive()) {
+            return 0.0F;
+        }
+
+        float exit = getExitStrength();
+        return getTravelStrength() * CAMERA_LIFT - exit * EXIT_CAMERA_SETTLE;
+    }
+
+    public static float getPitchOffset(final Player player, final float partialTick) {
+        if (isInactive()) {
+            return 0.0F;
+        }
+
+        PhaseSample phase = getPhaseSample();
+        float pitch = -phase.entry() * ENTRY_PITCH - phase.travel() * SUSTAIN_PITCH + phase.exit() * EXIT_REBOUND_PITCH;
+        return pitch + sampleMotion(getAnimationTime(player, partialTick), PITCH_MOTION) * phase.travel();
+    }
+
+    public static float getRollOffset(final Player player, final float partialTick) {
+        if (isInactive()) {
+            return 0.0F;
+        }
+
+        PhaseSample phase = getPhaseSample();
+        float time = getAnimationTime(player, partialTick);
+        float sway = Mth.sin(time * ROLL_SWAY_FREQUENCY + ROLL_SWAY_PHASE) * ROLL_SWAY * phase.cruise();
+        float shake = sampleMotion(time, ROLL_MOTION) * phase.travel();
+        return sway + shake;
+    }
+
+    public static float getCameraBobOffset(final Player player, final float partialTick) {
+        if (isInactive()) {
+            return 0.0F;
+        }
+
+        PhaseSample phase = getPhaseSample();
+        float time = getAnimationTime(player, partialTick);
+        float bob = Mth.sin(time * BOB_FREQUENCY + BOB_PHASE) * BOB_AMPLITUDE * phase.cruise();
+        float shake = sampleMotion(time, BOB_MOTION) * phase.travel();
+        return bob + shake;
+    }
+
+    public static float getZoomLerpFactor() {
+        if (isInactive()) {
+            return ZOOM_LERP_MIN;
+        }
+
+        return Mth.lerp(getTravelStrength(), ZOOM_LERP_MIN, ZOOM_LERP_MAX);
+    }
+
+    private static float getRawProgress(final Player player) {
+        if (!ServerFlightHandler.isSpin(player)) {
+            return 0.0F;
+        }
+
+        FlightData data = FlightData.getData(player);
+        int totalDuration = Math.max(ServerFlightHandler.SPIN_DURATION, 1);
+        return Mth.clamp(1.0F - data.duration / (float) totalDuration, 0.0F, 1.0F);
+    }
+
+    private static PhaseSample getPhaseSample() {
+        float entry = getEntryStrength();
+        float exit = getExitStrength();
+        float travel = entry * (1.0F - exit);
+        float cruise = travel * getPhaseProgress(CRUISE_RAMP_START, CRUISE_RAMP_END);
+        return new PhaseSample(entry, travel, cruise, exit);
+    }
+
+    private static float getEntryStrength() {
+        return easeInCubic(getPhaseProgress(0.0F, ENTRY_PHASE_END));
+    }
+
+    private static float getExitStrength() {
+        return easeOutCubic(getPhaseProgress(EXIT_PHASE_START, 1.0F));
+    }
+
+    private static float getTravelStrength() {
+        return getEntryStrength() * (1.0F - getExitStrength());
+    }
+
+    private static float getPhaseProgress(final float start, final float end) {
+        return Mth.clamp(Mth.inverseLerp(smoothedProgress, start, end), 0.0F, 1.0F);
+    }
+
+    private static float getAnimationTime(final Player player, final float partialTick) {
+        return player.tickCount + partialTick;
+    }
+
+    private static float sampleMotion(final float time, final MotionProfile profile) {
+        float sine = Mth.sin(time * profile.sineFrequency() + profile.phase()) * profile.sineAmplitude();
+        float noise = noise(time * profile.noiseFrequency() + profile.phase() * 1.7F) * profile.noiseAmplitude();
+        return sine + noise;
+    }
+
+    private static boolean isInactive() {
+        return smoothedProgress <= INACTIVE_EPSILON;
+    }
+
+    private static float noise(final float value) {
+        double raw = Math.sin(value * 12.9898D + 78.233D) * 43758.5453D;
+        return (float) ((raw - Math.floor(raw)) * 2.0D - 1.0D);
+    }
+
+    private static float easeInCubic(final float value) {
+        return value * value * value;
+    }
+
+    private static float easeOutCubic(final float value) {
+        float inverse = 1.0F - value;
+        return 1.0F - inverse * inverse * inverse;
+    }
+
+    private static void reset() {
+        smoothedProgress = 0.0F;
+    }
+
+    private record MotionProfile(float sineFrequency, float sineAmplitude, float noiseFrequency, float noiseAmplitude, float phase) {}
+
+    private record PhaseSample(float entry, float travel, float cruise, float exit) {}
+}

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/SpinFovHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/SpinFovHandler.java
@@ -1,0 +1,23 @@
+package by.dragonsurvivalteam.dragonsurvival.client.handlers;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ComputeFovModifierEvent;
+
+
+@EventBusSubscriber(Dist.CLIENT)
+public class SpinFovHandler {
+    @SubscribeEvent
+    public static void onFovEvent(final ComputeFovModifierEvent event) {
+        if (!ClientFlightHandler.spinCameraEffect) {
+            return;
+        }
+
+        float spinFovMultiplier = SpinFlightPresentation.getFovMultiplier(ClientFlightHandler.spinCameraFovStrength);
+
+        if (spinFovMultiplier != 1.0F) {
+            event.setNewFovModifier(event.getNewFovModifier() * spinFovMultiplier);
+        }
+    }
+}


### PR DESCRIPTION
Refines dragon spin camera presentation during spin flight.

Adds a small phase-driven client presentation flow for zoom, FOV, pitch/roll, detached camera offset, and bob.

Keeps the change client-side only and scoped to spin camera behavior.

Tested locally with successful compile and in-game manual verification.