### PR TITLE
Fix crash when Bedrockoid is installed

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/blocks/DragonPressurePlates.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/blocks/DragonPressurePlates.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.fml.ModList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,7 +95,10 @@ public class DragonPressurePlates extends PressurePlateBlock implements SimpleWa
     protected void createBlockStateDefinition(@NotNull final Builder<Block, BlockState> builder) {
         super.createBlockStateDefinition(builder);
         builder.add(FACING);
-        builder.add(WATERLOGGED);
+        // Bedrockoid adds WATERLOGGED to PressurePlateBlock via mixin - skip to avoid duplicate property crash
+        if (!ModList.get().isLoaded("bedrockoid")) {
+            builder.add(WATERLOGGED);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #943

Bedrockoid (https://www.curseforge.com/minecraft/mc-mods/bedrockoid) adds `WATERLOGGED` to `PressurePlateBlock` via mixin as part of Bedrock Edition parity. `DragonPressurePlates.createBlockStateDefinition` calls `super` (which now includes `WATERLOGGED` from Bedrockoid) and then adds `WATERLOGGED` again, causing:

```
java.lang.IllegalArgumentException: Block{[unregistered]} has duplicate property: waterlogged
    at DragonPressurePlates.createBlockStateDefinition(DragonPressurePlates.java:97)
```

This cascades and also breaks Waystones and Create during mod loading.

**Fix:** Skip `builder.add(WATERLOGGED)` when Bedrockoid is loaded, since the parent class already has it registered.

Note: this is arguably a Bedrockoid bug (their mixin breaks any PressurePlateBlock subclass that independently implements SimpleWaterloggedBlock), but this guard prevents the crash on the Dragon Survival side.