### PR TITLE
Fix: dragon soul showing wrong stage name & growth crystal showing wrong modifier level

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/GrowthCrystalButton.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/gui/widgets/buttons/GrowthCrystalButton.java
@@ -105,7 +105,7 @@ public class GrowthCrystalButton extends ExtendedButton {
         components.add(Component.translatable(LangKey.GROWTH_MODIFIERS_AT_MAX_GROWTH));
 
         for (Modifier modifier : stage.value().modifiers()) {
-            MutableComponent name = modifier.getFormattedDescription((int) stage.value().growthRange().max(), true);
+            MutableComponent name = modifier.getFormattedDescription((int) (stage.value().growthRange().max() - stage.value().growthRange().min()), true);
             components.add(name);
         }
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonSoulItem.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/items/DragonSoulItem.java
@@ -50,6 +50,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 public class DragonSoulItem extends BlockItem {
     @ConfigRange(min = 0)
@@ -266,7 +267,20 @@ public class DragonSoulItem extends BlockItem {
             }
 
             double growth = handlerData.getDouble(DragonStateHandler.GROWTH);
-            Holder<DragonStage> stage = DragonStage.get(provider, growth);
+
+            // Prioritize the exact stage key stored in NBT to avoid cross-addon stage name mismatch
+            ResourceKey<DragonStage> stageKey = ResourceHelper.decodeKey(provider, DragonStage.REGISTRY, handlerData, DragonStateHandler.DRAGON_STAGE);
+            Holder<DragonStage> stage;
+            if (stageKey != null) {
+                Optional<Holder.Reference<DragonStage>> storedStage = ResourceHelper.get(provider, stageKey);
+                if (storedStage.isPresent()) {
+                    stage = storedStage.get();
+                } else {
+                    stage = DragonStage.get(provider, growth);
+                }
+            } else {
+                stage = DragonStage.get(provider, growth);
+            }
 
             //noinspection DataFlowIssue -> key is present
             tooltips.add(Component.translatable(INFO, name, DragonStage.translatableName(stage.getKey()), String.format("%.0f", growth)));


### PR DESCRIPTION
## What this fixes

### Bug 1: Dragon soul tooltip shows wrong stage name

**When it happens:** Playing with addons that add custom dragon stages (like Dragon Survival Expanded).

**Why:** The game looks up a stage by growth number (e.g. "25") across ALL registered stages globally. If two addons both have a stage covering growth 25, which one gets picked is random — it depends on mod load order.

**The fix:** The dragon soul item already saves the exact stage it belongs to in its NBT data. Now we read that stored stage first instead of searching blindly by growth number. If the stored data is missing (old items), it falls back to the old behavior.

### Bug 2: Growth crystal modifier numbers are off

**When it happens:** When viewing the growth crystal tooltip for stages beyond the first one.

**Why:** The modifier display was using `stage.growthRange().max()` directly. For example, stage 2 has range 10-25, so it showed "25" instead of "15" (the actual growth within that stage).

**The fix:** Now subtracts `min()` from `max()`, so each stage shows numbers relative to its own range.

## Files changed

- `DragonSoulItem.java` — read stage from stored NBT key before falling back to growth lookup
- `GrowthCrystalButton.java` — offset modifier display level by stage minimum