### PR TITLE
Fix dragon body disappearing when holding items with glow outline enabled

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonItemRenderLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonItemRenderLayer.java
@@ -3,9 +3,12 @@ package by.dragonsurvivalteam.dragonsurvival.client.render.entity.dragon;
 import by.dragonsurvivalteam.dragonsurvival.client.render.ClientDragonRenderer;
 import by.dragonsurvivalteam.dragonsurvival.common.entity.DragonEntity;
 import by.dragonsurvivalteam.dragonsurvival.compat.bettercombat.BetterCombat;
-import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.OutlineBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.util.FastColor;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
@@ -14,6 +17,7 @@ import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.renderer.GeoRenderer;
 import software.bernie.geckolib.renderer.layer.BlockAndItemGeoLayer;
 
+import java.util.Optional;
 import java.util.function.BiFunction;
 
 public class DragonItemRenderLayer extends BlockAndItemGeoLayer<DragonEntity> {
@@ -57,7 +61,50 @@ public class DragonItemRenderLayer extends BlockAndItemGeoLayer<DragonEntity> {
                 poseStack.scale(0.75F, 0.75F, 0.75F);
             }
 
-            super.renderStackForBone(poseStack, bone, stack, animatable, bufferSource, partialTick, packedLight, packedOverlay);
+            // Isolate the outline buffer for item rendering to prevent the glow
+            // pass from interfering with the dragon body visibility
+            MultiBufferSource.BufferSource[] itemOutlineBufHolder = new MultiBufferSource.BufferSource[1];
+            MultiBufferSource effectiveSource = bufferSource;
+
+            if (bufferSource instanceof OutlineBufferSource outline) {
+                MultiBufferSource.BufferSource normalBuf = outline.bufferSource;
+                int color = FastColor.ARGB32.color(outline.teamA, outline.teamR, outline.teamG, outline.teamB);
+                MultiBufferSource.BufferSource itemOutlineBuf = MultiBufferSource.immediate(new ByteBufferBuilder(1536));
+                itemOutlineBufHolder[0] = itemOutlineBuf;
+
+                effectiveSource = new MultiBufferSource() {
+                    @Override
+                    public VertexConsumer getBuffer(RenderType rt) {
+                        if (rt.isOutline()) {
+                            return itemOutlineBuf.getBuffer(rt);
+                        }
+                        VertexConsumer normal = normalBuf.getBuffer(rt);
+                        Optional<RenderType> outlineVariant = rt.outline();
+                        if (outlineVariant.isPresent()) {
+                            VertexConsumer outConsumer = itemOutlineBuf.getBuffer(outlineVariant.get());
+                            return VertexMultiConsumer.create(new VertexConsumer() {
+                                public VertexConsumer addVertex(float x, float y, float z) {
+                                    outConsumer.addVertex(x, y, z).setColor(color);
+                                    return this;
+                                }
+                                public VertexConsumer setColor(int r, int g, int b, int a) { return this; }
+                                public VertexConsumer setUv(float u, float v) { outConsumer.setUv(u, v); return this; }
+                                public VertexConsumer setUv1(int u, int v) { return this; }
+                                public VertexConsumer setUv2(int u, int v) { return this; }
+                                public VertexConsumer setNormal(float x, float y, float z) { return this; }
+                            }, normal);
+                        }
+                        return normal;
+                    }
+                };
+            }
+
+            super.renderStackForBone(poseStack, bone, stack, animatable, effectiveSource, partialTick, packedLight, packedOverlay);
+
+            if (itemOutlineBufHolder[0] != null) {
+                itemOutlineBufHolder[0].endBatch();
+            }
+
             poseStack.popPose();
         }
     }

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonRenderer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonRenderer.java
@@ -25,6 +25,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3d;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
+import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.model.GeoModel;
 import software.bernie.geckolib.renderer.GeoEntityRenderer;
 import software.bernie.geckolib.util.Color;
@@ -89,6 +90,13 @@ public class DragonRenderer extends GeoEntityRenderer<DragonEntity> {
     @Override
     public void preRender(final PoseStack poseStack, final DragonEntity animatable, final BakedGeoModel model, final MultiBufferSource bufferSource, final VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, int color) {
         Minecraft.getInstance().getProfiler().push("player_dragon");
+
+        // Reset all bone visibility before each render pass to prevent
+        // the glow outline pass from affecting the main render pass
+        for (GeoBone bone : model.topLevelBones()) {
+            resetBoneVisibility(bone);
+        }
+
         Player player = animatable.getPlayer();
 
         resetNeckVisibility = model.getBone("Neck").map(bone -> {
@@ -191,6 +199,13 @@ public class DragonRenderer extends GeoEntityRenderer<DragonEntity> {
         float scale = (float) handler.getVisualScale(player, partialTicks) * (float) handler.body().value().scalingProportions().scaleMultiplier();
 
         return new Vec3(x * scale, 0, z * scale);
+    }
+
+    private static void resetBoneVisibility(GeoBone bone) {
+        bone.setHidden(false);
+        for (GeoBone child : bone.getChildBones()) {
+            resetBoneVisibility(child);
+        }
     }
 
     @Override // Also used by the layers

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -47,3 +47,10 @@ public net.minecraft.world.entity.projectile.AbstractArrow setPierceLevel(B)V # 
 public net.minecraft.world.entity.projectile.AbstractArrow inGround # inGround
 
 public-f net.minecraft.data.loot.LootTableProvider getName()Ljava/lang/String; # getName
+
+public net.minecraft.client.renderer.OutlineBufferSource bufferSource
+public net.minecraft.client.renderer.OutlineBufferSource outlineBufferSource
+public net.minecraft.client.renderer.OutlineBufferSource teamR
+public net.minecraft.client.renderer.OutlineBufferSource teamG
+public net.minecraft.client.renderer.OutlineBufferSource teamB
+public net.minecraft.client.renderer.OutlineBufferSource teamA


### PR DESCRIPTION
## What this fixes

When all three conditions are met — `renderHeldItem` enabled in config, the dragon has a glow outline (spectral arrow / team glow), and the dragon is holding an item — the dragon body can disappear entirely.

## Why

The glow render pass hides some bones during item rendering. Because the item`s outline data bleeds into the same buffer, those bones stay hidden when the main render pass runs — so the body isn`t drawn for that frame.

## What changed

- **`DragonRenderer.java`** — Reset all bone visibility at the start of each `preRender` so bones hidden by the outline pass don`t stay hidden for the main pass.

- **`DragonItemRenderLayer.java`** — Isolate the outline buffer when rendering items on the dragon, preventing item outlines from interfering with the body`s buffer state.

- **`accesstransformer.cfg`** — Added access transformer entries for `OutlineBufferSource` private fields needed by the item render layer fix.