### PR TITLE
Fix crash when Gitee API returns invalid JSON during skin loading

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/GiteeSkinLoader.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/skins/GiteeSkinLoader.java
@@ -5,6 +5,7 @@ import by.dragonsurvivalteam.dragonsurvival.util.json.GsonFactory;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import net.neoforged.neoforge.common.util.Lazy;
 
@@ -76,7 +77,7 @@ public class GiteeSkinLoader implements NetSkinLoader {
                     return directoryInfo.sha;
                 }
             }
-        } catch (IOException exception) {
+        } catch (IOException | JsonSyntaxException exception) {
             return "";
         }
 


### PR DESCRIPTION
## What this fixes

Game crashes on startup when `GiteeSkinLoader` queries the Gitee API and receives an invalid JSON response. This can happen during network instability.

## Why

`GiteeSkinLoader.querySkinDirectoryHash()` catches `IOException`, but Gson can throw `JsonSyntaxException` when the API response is not valid JSON. Since `JsonSyntaxException` is a `RuntimeException` (not `IOException`), it slips through and crashes the game.

## Fix

Added `JsonSyntaxException` to the existing catch clause.

## Crash log

```
Caused by: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was STRING at line 1 column 1 path $
    at com.google.gson.stream.JsonReader.beginArray(JsonReader.java:358)
    at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(...)
    at com.google.gson.Gson.fromJson(Gson.java:1227)
    at by.dragonsurvivalteam.dragonsurvival.client.skins.GiteeSkinLoader.querySkinDirectoryHash(GiteeSkinLoader.java:73)
    at net.neoforged.neoforge.common.util.Lazy.get(Lazy.java:49)
    at by.dragonsurvivalteam.dragonsurvival.client.skins.GiteeSkinLoader.querySkinList(GiteeSkinLoader.java:90)
    at by.dragonsurvivalteam.dragonsurvival.client.skins.DragonSkins.init(DragonSkins.java:239)
    at by.dragonsurvivalteam.dragonsurvival.client.handlers.DragonSkinReloadHandler.onCommonSetupSkin(DragonSkinReloadHandler.java:13)
```