### PR TITLE
Fix Dragon Armor Flickering Cuased by Curios with "Fancy/Animated" names

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/render/entity/dragon/DragonArmorRenderLayer.java
@@ -442,7 +442,7 @@ public class DragonArmorRenderLayer extends GeoRenderLayer<DragonEntity> {
         ArrayList<ItemStack> visibleCurios = CurioAPIHelper.getVisibleCurioItems(player);
         if (visibleCurios != null) {
             for (ItemStack curio : visibleCurios) {
-                armorTotal.append(separator).append(curio.getDisplayName());
+                armorTotal.append(separator).append(curio.getDisplayName().getString()); //use getString() for unformatted name (fixes armor flickering due to constantly-changing UUID from curios with "animated" name colors)
             }
         }
 


### PR DESCRIPTION
base armor texture UUID on unformatted curio name, so curios with animated scrolling/shimmer of name colors do not affect it