### PR TITLE
Properly check for Graceful Player landings, and fold wings after a set time

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/common/capability/DragonStateHandler.java
@@ -105,6 +105,8 @@ public class DragonStateHandler extends EntityStateHandler {
     /** Last timestamp the server synchronized the player */
     public int lastSync;
 
+    public int foldWingsTimer = 0;
+
     private final Map<ResourceKey<DragonSpecies>, Double> savedGrowth = new HashMap<>();
     private final Map<ResourceKey<DragonSpecies>, Double> savedDesiredGrowth = new HashMap<>();
     private SkinData skinData = new SkinData();
@@ -661,6 +663,7 @@ public class DragonStateHandler extends EntityStateHandler {
             tag.putBoolean(MARKED_BY_ENDER_DRAGON, markedByEnderDragon);
             tag.putBoolean(WINGS_WAS_GRANTED, flightWasGranted);
             tag.putBoolean(SPIN_WAS_GRANTED, spinWasGranted);
+            tag.putInt(FOLD_WINGS_TIMER, foldWingsTimer);
         }
 
         // TODO :: these probably shouldn't be applied to other players (dragon soul)?
@@ -757,6 +760,7 @@ public class DragonStateHandler extends EntityStateHandler {
             markedByEnderDragon = tag.getBoolean(MARKED_BY_ENDER_DRAGON);
             flightWasGranted = tag.getBoolean(WINGS_WAS_GRANTED);
             spinWasGranted = tag.getBoolean(SPIN_WAS_GRANTED);
+            foldWingsTimer = tag.getInt(FOLD_WINGS_TIMER);
         }
 
         if (isDragonSoul) {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
@@ -116,8 +116,9 @@ public class ServerFlightHandler {
         if (player instanceof ServerPlayer && DragonStateProvider.isDragon(player)) {
             DragonStateHandler handler = DragonStateProvider.getData(player);
             if (player.onGround() && foldWingsOnLand) {
-                if (handler.foldWingsTimer > 0)
+                if (handler.foldWingsTimer > 0) {
                     handler.foldWingsTimer--;
+                }
                 else if (handler.foldWingsTimer == 0) {
                     FlightData.getData(player).areWingsSpread = false;
                     PacketDistributor.sendToPlayersTrackingEntityAndSelf(player, new SyncWingsSpread(player.getId(), false));

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
@@ -64,6 +64,11 @@ public class ServerFlightHandler {
     public static Boolean foldWingsOnLand = false;
 
     @ConfigRange(min = 0)
+    @Translation(key = "fold_wings_delay", type = Translation.Type.CONFIGURATION, comments = "How long (in ticks) a Dragon must be on the ground before flight mode is disabled")
+    @ConfigOption(side = ConfigSide.SERVER, category = "wings", key = "fold_wings_delay")
+    public static int foldWingsDelay=20;
+    
+    @ConfigRange(min = 0)
     @Translation(key = "flight_spin_cooldown", type = Translation.Type.CONFIGURATION, comments = "Cooldown (in seconds) of the spin attack during flight")
     @ConfigOption(side = ConfigSide.SERVER, category = "wings", key = "flight_spin_cooldown")
     public static Integer flightSpinCooldown = 5;
@@ -97,7 +102,6 @@ public class ServerFlightHandler {
     @ConfigOption(side = ConfigSide.SERVER, category = "wings", key = "no_speed_requirement_for_vertical_acceleration")
     public static Boolean noSpeedRequirementForVerticalAcceleration = false;
 
-    public static int foldWingsDelay=20; //how long a player must be landed before flight mode is disabled
 
     @SubscribeEvent(receiveCanceled = true) // Unsure if this is needed
     public static void handleLanding(final LivingFallEvent event) {
@@ -116,7 +120,7 @@ public class ServerFlightHandler {
                     handler.foldWingsTimer--;
                 else if (handler.foldWingsTimer == 0) {
                     FlightData.getData(player).areWingsSpread = false;
-                    PacketDistributor.sendToPlayersTrackingEntityAndSelf(player, new SyncWingsSpread(player.getId(), false), new CustomPacketPayload[0]);
+                    PacketDistributor.sendToPlayersTrackingEntityAndSelf(player, new SyncWingsSpread(player.getId(), false));
                     handler.foldWingsTimer = -1;
                 }
             } else {

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/server/handlers/ServerFlightHandler.java
@@ -97,6 +97,8 @@ public class ServerFlightHandler {
     @ConfigOption(side = ConfigSide.SERVER, category = "wings", key = "no_speed_requirement_for_vertical_acceleration")
     public static Boolean noSpeedRequirementForVerticalAcceleration = false;
 
+    public static int foldWingsDelay=20; //how long a player must be landed before flight mode is disabled
+
     @SubscribeEvent(receiveCanceled = true) // Unsure if this is needed
     public static void handleLanding(final LivingFallEvent event) {
         if (event.getEntity() instanceof Player player) {
@@ -104,6 +106,25 @@ public class ServerFlightHandler {
         }
     }
 
+    @SubscribeEvent
+    public void handleGracefulLanding(PlayerTickEvent.Pre event) {
+        Player player = event.getEntity();
+        if (player instanceof ServerPlayer && DragonStateProvider.isDragon(player)) {
+            DragonStateHandler handler = DragonStateProvider.getData(player);
+            if (player.onGround() && foldWingsOnLand) {
+                if (handler.foldWingsTimer > 0)
+                    handler.foldWingsTimer--;
+                else if (handler.foldWingsTimer == 0) {
+                    FlightData.getData(player).areWingsSpread = false;
+                    PacketDistributor.sendToPlayersTrackingEntityAndSelf(player, new SyncWingsSpread(player.getId(), false), new CustomPacketPayload[0]);
+                    handler.foldWingsTimer = -1;
+                }
+            } else {
+                handler.foldWingsTimer = foldWingsDelay;
+            }
+        }
+    }
+    
     @SubscribeEvent
     public static void handleLanding(final PlayerFlyableFallEvent event) {
         if (event.getEntity() instanceof Player player) {


### PR DESCRIPTION
allow "FoldWingsOnLand" to function after graceful landings that would not trigger the events that the existing methods relied on