### PR TITLE
Fix Transition From Gliding to Hovering

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -357,7 +357,10 @@ public class ClientFlightHandler {
                                     }
                                 }
 
-                                if (ServerFlightHandler.isGliding(player) || ax != 0 || az != 0) {
+                                double speedThreshold = flightSpeedMultiplier;
+                                Vec3 velocity = new Vec3(ax,ay,az);
+                                //use minimum speed threshold to properly handle transition from gliding to hovering
+                                if (ServerFlightHandler.isGliding(player) || velocity.length() > speedThreshold) {
                                     deltaMovement = player.getDeltaMovement().add(0.0D, gravity * (-1.0D + (double) verticalDelta * 0.75D), 0.0D);
 
                                     if (deltaMovement.y < 0 && horizontalView > 0) {
@@ -409,9 +412,7 @@ public class ClientFlightHandler {
                                         player.setDeltaMovement(deltaMovement);
                                         ay = player.getDeltaMovement().y;
                                     }
-                                }
-
-                                if (!ServerFlightHandler.isGliding(player)) {
+                                } else if (!ServerFlightHandler.isGliding(player)) { //only run this if the gliding code is not already handling deceleration/transition to hover
                                     wasGliding = false;
                                     double maxForward = 0.5 * flightSpeedMultiplier * 2;
 

--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -412,7 +412,8 @@ public class ClientFlightHandler {
                                         player.setDeltaMovement(deltaMovement);
                                         ay = player.getDeltaMovement().y;
                                     }
-                                } else if (!ServerFlightHandler.isGliding(player)) { //only run this if the gliding code is not already handling deceleration/transition to hover
+                                //only run this if the gliding code is not already handling deceleration/transition to hover
+                                } else if (!ServerFlightHandler.isGliding(player)) { 
                                     wasGliding = false;
                                     double maxForward = 0.5 * flightSpeedMultiplier * 2;
 


### PR DESCRIPTION
improve/fix transition from gliding to flying by using a speed threshold

prevents unwanted "drifting" when transitioning back to hover by allowing glide momentum to drop to 0

previously the look up/down momentum functions for gliding would keep the momentum at a low value and prevent if from dropping to 0 when transitioning back to hover mode