### PR TITLE
Modify jumpToFly logic to allow takeoff from the water surface

### DIFF
--- a/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
+++ b/src/main/java/by/dragonsurvivalteam/dragonsurvival/client/handlers/ClientFlightHandler.java
@@ -521,7 +521,9 @@ public class ClientFlightHandler {
             return;
         }
 
-        if (player.isInLava() || player.isInWater()) {
+        //check if eye is in fluid, rather than isInWater()/isInLava(), which checks feet
+        //this allows jumpToFly to work from the surface of the water
+        if (player.getEyeInFluidType() != (FluidType)NeoForgeMod.EMPTY_TYPE.value()) {
             return;
         }
 


### PR DESCRIPTION
check `player.getEyeInFluidType()` rather than `player.isInWater()`/`player.isInLava()`, which check for fluid at the player's feet level, to allow jumpToFly activation from the water's surface

previous behavior: 
jumpToFly did not activate even when at the water's surface, requiring use of the dedicated flight toggle keybind to take off

there is no existing code in place that prevents activating flight manually while in or even under water, and it appears the intention of this condition was as a convenience to prevent accidental flight activation while swimming, rather than to prevent taking off from the surface entirely